### PR TITLE
[SEARCH-1494] ACCOUNT: Add links to Bentley & Clements Aeon instances to pending & past activity displays

### DIFF
--- a/views/past-activity/special-collections.erb
+++ b/views/past-activity/special-collections.erb
@@ -1,1 +1,3 @@
 <p>You must visit <a href="http://aeon.lib.umich.edu/logon">your Special Collections account</a> to renew or get more info on Special Collection items.</p>
+
+<p>Go to your <a href="https://aeon.bentley.umich.edu/login">Bentley Historical Library</a> or <a href="https://aeon.clements.umich.edu/logon">Clements Library</a> account pages for information on requests submitted through those libraries.</p>

--- a/views/past-activity/special-collections.erb
+++ b/views/past-activity/special-collections.erb
@@ -1,3 +1,3 @@
-<p>You must visit <a href="http://aeon.lib.umich.edu/logon">your Special Collections account</a> to renew or get more info on Special Collection items.</p>
+<p>Visit your <a href="https://aeon.lib.umich.edu/logon">Special Collections Request Account</a> to access details about past requests from the <a href="https://www.lib.umich.edu/locations-and-hours/special-collections-research-center">Special Collections Research Center</a>.</p>
 
 <p>Go to your <a href="https://aeon.bentley.umich.edu/login">Bentley Historical Library</a> or <a href="https://aeon.clements.umich.edu/logon">Clements Library</a> account pages for information on requests submitted through those libraries.</p>

--- a/views/pending-requests/special-collections.erb
+++ b/views/pending-requests/special-collections.erb
@@ -1,1 +1,3 @@
 <p>You must visit <a href="http://aeon.lib.umich.edu/logon">your Special Collections account</a> to renew or get more info on Special Collection items.</p>
+
+<p>Go to your <a href="https://aeon.bentley.umich.edu/login">Bentley Historical Library</a> or <a href="https://aeon.clements.umich.edu/logon">Clements Library</a> account pages for information on requests submitted through those libraries.</p>

--- a/views/pending-requests/special-collections.erb
+++ b/views/pending-requests/special-collections.erb
@@ -1,3 +1,3 @@
-<p>You must visit <a href="http://aeon.lib.umich.edu/logon">your Special Collections account</a> to renew or get more info on Special Collection items.</p>
+<p>Visit your <a href="https://aeon.lib.umich.edu/logon">Special Collections Request Account</a> to track requests from the <a href="https://www.lib.umich.edu/locations-and-hours/special-collections-research-center">Special Collections Research Center</a>.</p>
 
 <p>Go to your <a href="https://aeon.bentley.umich.edu/login">Bentley Historical Library</a> or <a href="https://aeon.clements.umich.edu/logon">Clements Library</a> account pages for information on requests submitted through those libraries.</p>


### PR DESCRIPTION
# Overview
Users who have submitted Aeon requests to Bentley or Clements cannot access them through Pending Requests or Past Activity.

On both [https://account.lib.umich.edu/pending-requests/special-collections](https://account.lib.umich.edu/pending-requests/special-collections) and [https://account.lib.umich.edu/past-activity/special-collections](https://account.lib.umich.edu/past-activity/special-collections) we show the text: You must visit [your Special Collections account](http://aeon.lib.umich.edu/logon) to renew or get more info on Special Collection items.

Add to that:  
> Go to your [Bentley Historical Library](https://aeon.bentley.umich.edu/login) or [Clements Library](https://aeon.clements.umich.edu/logon) account pages for information on requests submitted through those libraries. 

---

...

On Pending Requests can we change it to:

> Visit your [Special Collections Request Account](https://aeon.lib.umich.edu/logon) to track requests from the [Special Collections Research Center](https://www.lib.umich.edu/locations-and-hours/special-collections-research-center).

And on Past Activity to:

> Visit your [Special Collections Request Account](https://aeon.lib.umich.edu/logon) to access details about past requests from the [Special Collections Research Center](https://www.lib.umich.edu/locations-and-hours/special-collections-research-center).

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Navigate to [Pending Requests > Special Collections](http://localhost:4567/pending-requests/special-collections) and [Past Activity > Special Collections](http://localhost:4567/past-activity/special-collections) to see if the new text show up.
  * Click on the links to make sure you're correctly navigated.