### PR TITLE
[DAT-60] Colors

### DIFF
--- a/css/_dropdown.scss
+++ b/css/_dropdown.scss
@@ -27,7 +27,7 @@
   @media screen and ($breakpoint-medium) {
     &[aria-expanded="true"] > span {
       text-decoration: underline;
-      text-decoration-thickness: 2px;
+      text-decoration-thickness: var(--space-xxx-small);
     }
   }
 }
@@ -68,12 +68,7 @@
     &:hover,
     &:focus {
       text-decoration: underline;
-      text-decoration-thickness: 2px;
-    }
-
-    &.active {
-      color: var(--color-teal-400);
-      font-weight: 800;
+      text-decoration-thickness: var(--space-xxx-small);
     }
 
     m-icon {
@@ -84,6 +79,6 @@
   }
   li.active a {
     color: var(--color-teal-400);
-    font-weight: bold;
+    font-weight: 800;
   }
 }

--- a/css/_dropdown.scss
+++ b/css/_dropdown.scss
@@ -27,6 +27,7 @@
   @media screen and ($breakpoint-medium) {
     &[aria-expanded="true"] > span {
       text-decoration: underline;
+      text-decoration-thickness: 2px;
     }
   }
 }
@@ -67,11 +68,12 @@
     &:hover,
     &:focus {
       text-decoration: underline;
+      text-decoration-thickness: 2px;
     }
 
     &.active {
       color: var(--color-teal-400);
-      font-weight: var(--semibold);
+      font-weight: 800;
     }
 
     m-icon {

--- a/css/_horizontal-navigation.scss
+++ b/css/_horizontal-navigation.scss
@@ -46,7 +46,7 @@
   
       &:hover {
         text-decoration: underline;
-        text-decoration-thickness: 2px;
+        text-decoration-thickness: var(--space-xxx-small);
       }
 
       &[aria-current="page"] {

--- a/css/_site-navigation.scss
+++ b/css/_site-navigation.scss
@@ -45,7 +45,7 @@
     &:hover,
     &:focus {
       text-decoration: underline;
-      text-decoration-thickness: 2px;
+      text-decoration-thickness: var(--space-xxx-small);
     }
 
     m-icon {

--- a/css/_site-navigation.scss
+++ b/css/_site-navigation.scss
@@ -7,8 +7,8 @@
   }
   ul {
     list-style: none;
-    padding: 0;
     margin: 0;
+    padding: 0;
   }
 
   li {
@@ -21,30 +21,37 @@
 
     &.active a {
       color: var(--color-teal-400);
-      font-weight: bold;
+      font-weight: 800;
+
+      &::before {
+        background-color: var(--color-teal-400);
+        content: '';
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: var(--space-xx-small);
+      }
     }
   }
 
   a {
-    display: block;
-    text-decoration: none;
     color: var(--color-neutral-400);
-    padding: var(--space-medium) 0;
+    display: block;
+    padding: var(--space-medium);
+    position: relative;
+    text-decoration: none;
 
     &:hover,
     &:focus {
       text-decoration: underline;
-    }
-
-    &.active {
-      color: var(--color-teal-400);
-      font-weight: var(--semibold);
+      text-decoration-thickness: 2px;
     }
 
     m-icon {
+      margin-right: var(--space-xx-small);
       position: relative;
       top: var(--space-xxx-small);
-      margin-right: var(--space-xx-small);
     }
   }
 }


### PR DESCRIPTION
# Overview

There is not much a visual cue in the sidebar navigation to indicate what the current active page/parent is. DAT suggested to add a left border. One has been added that matches the thickness of the horizontal navigation. The active `font-weight` and underline-thickness now also match in the sidebar, horizontal navigation, and the dropdown menus.

Resolves #209.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Check the sidebar navigation to see if the left border appears.
* Check to see if the underline thickness has been updated, and the font-weight has been updated in both the sidebar and dropdown navigations.