### PR TITLE
[DAT-60] Page structure/Landmarks

### DIFF
--- a/views/layout/navigation.erb
+++ b/views/layout/navigation.erb
@@ -1,6 +1,6 @@
 <% my_pages = Navigation::Sidebar.for(request.path_info) %>
 
-<nav class="site-navigation site-layout__left">
+<nav class="site-navigation site-layout__left" aria-label="Site Navigation">
   <div class="sticky-top">
     <ul class="site-navigation-list">
       <% my_pages.pages.each do |page| %>

--- a/views/layout/user_drop_down.erb
+++ b/views/layout/user_drop_down.erb
@@ -1,6 +1,6 @@
 <% dropdown = Navigation::UserDropdown.for(request.path_info) %>
 
-<nav class="user-navigation dropdown">
+<nav class="user-navigation dropdown" aria-label="User Dropdown Navigation">
   <button aria-expanded="false" data-dropdown="user-nav-dropdown" class="button--dropdown">
     <m-icon name="person-outline"></m-icon>
     <span><%=session[:uniqname]%></span>


### PR DESCRIPTION
# Overview
AXE gives a warning that there are duplicate landmarks for ‘navigation’ (user account drop down and left hand navigation). This pull request adds labelling to the `nav` elements.

The other remaining warnings within the issue can only be changed through the design system.

Resolves #211.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken