### PR TITLE
[DAT-60] Screen Reader Confirmation Messages

### DIFF
--- a/views/components/message.erb
+++ b/views/components/message.erb
@@ -1,4 +1,4 @@
-<section class="message message--<%= kind %>">
+<section class="message message--<%= kind %>" role="alert">
   <h2 class="visually-hidden">Important message</h2>
   <p><%= message %></p>
 </section>

--- a/views/current-checkouts/_message-callout.erb
+++ b/views/current-checkouts/_message-callout.erb
@@ -1,15 +1,15 @@
-<div class="message-callout <% if message.renewed? and !message.not_renewed? %>message-callout--success<% elsif message.not_renewed? %>message-callout--warning<% end %> can-close">
+<div class="message-callout <% if message.renewed? and !message.not_renewed? %>message-callout--success<% elsif message.not_renewed? %>message-callout--warning<% end %> can-close" role="status">
   <button class="button--light button--close close-message" disabled>
     <m-icon name="close"></m-icon><span class="visually-hidden">Close</span>
   </button>
-  <div class="message-callout-icon" aria-live="polite">
+  <div class="message-callout-icon">
     <% if message.renewed? and !message.not_renewed? %>
       <m-icon name="check"></m-icon>
     <% elsif message.not_renewed? %>
       <m-icon name="info"></m-icon>
     <% end %>
   </div>
-  <div class="message-callout-content" aria-live="polite">
+  <div class="message-callout-content">
     <% if message.renewed? %>
       <p><span class="strong"><%= message.renewed_text %></span></p>
     <% end %>


### PR DESCRIPTION
# Overview
Messages and message callouts have been added the appropriate roles (`alert` and `status`) to trigger the appropriate `aria-live` value.

Resolves #207.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Navigate to [Current Checkouts: U-M Library](http://localhost:4567/current-checkouts/u-m-library) and test the "Renew All" function.
* Navigate to [Settings](http://localhost:4567/settings) and update checkout history to test the "Important Message" callout.