### PR TITLE
[DAT-60] Favorites Link

### DIFF
--- a/views/account-overview/index.erb
+++ b/views/account-overview/index.erb
@@ -3,7 +3,10 @@
     <li>
       <a href="<%=card.slug%>" class="overview-card">
         <div>
-          <h2 class="overview-card-heading"><%=card.title%></h2>
+          <h2 class="overview-card-heading">
+            <%=card.title%>
+            <%= erb :'components/open_in_new', locals: { title: card.title } %>
+          </h2>
           <p class="overview-card-description"><%=card.description%></p>
         </div>
         <div class="overview-card-icon-container" style="--overview-card-icon-background-color: var(--color-<%=card.color%>-100); --overview-card-icon-color: var(--color-<%=card.color%>-400);">

--- a/views/components/open_in_new.erb
+++ b/views/components/open_in_new.erb
@@ -1,0 +1,3 @@
+<% if title == "Favorites" %>
+  <m-icon name="open-in-new"></m-icon><span class="visually-hidden">(link redirects to external site)</span>
+<% end %>

--- a/views/layout/navigation.erb
+++ b/views/layout/navigation.erb
@@ -7,6 +7,7 @@
         <li class="<%= page.active %>">
           <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
             <m-icon name="<%=page.icon_name%>"></m-icon><span><%=page.title%></span>
+            <%= erb :'components/open_in_new', locals: { title: page.title } %>
           </a>
         </li>
       <% end %>


### PR DESCRIPTION
# Overview
The [Favorites](http://localhost:4567/favorites) link redirects to [https://apps.lib.umich.edu/my-account/favorites](https://apps.lib.umich.edu/my-account/favorites). This creates confusion in usability. An `open-in-new` icon has been added, along with visually hidden text to warn screen readers that they will be redirected to an external link if they navigate to it.

Resolves #208.

## Testing
* Run tests to make sure they pass (`docker-compose run web bundle exec rspec`)
* Go through the site to make sure nothing is broken
* Navigate to [Account Overview](http://localhost:4567/) to see if the icon shows up.
  * `Inspect Element` to see if the visually hidden text is there.