### PR TITLE
[LIBSEARCH-896] ACCOUNT: Accessibility warning

### DIFF
--- a/views/account-overview/index.erb
+++ b/views/account-overview/index.erb
@@ -9,7 +9,7 @@
           <p class="overview-card-description"><%=card.description%></p>
         </div>
         <div class="overview-card-icon-container" style="--overview-card-icon-background-color: var(--color-<%=card.color%>-100); --overview-card-icon-color: var(--color-<%=card.color%>-500);">
-          <span class="material-symbols-rounded"><%=card.icon_name%></span>
+          <span class="material-symbols-rounded" aria-hidden="true"><%=card.icon_name%></span>
         </div>
       </a>
     </li>

--- a/views/components/open_in_new.erb
+++ b/views/components/open_in_new.erb
@@ -1,1 +1,1 @@
-<% if title == "Favorites" %><span class="material-symbols-rounded">open_in_new</span><span class="visually-hidden">(link redirects to external site)</span><% end %>
+<% if title == "Favorites" %><span class="material-symbols-rounded" aria-hidden="true">open_in_new</span><span class="visually-hidden">(link redirects to external site)</span><% end %>

--- a/views/components/pagination.erb
+++ b/views/components/pagination.erb
@@ -5,7 +5,7 @@
     <li class="pagination-page">
       <a href="<%=pagination.previous.url%>" class="pagination-page-link">
         <span class="visually-hidden">Previous page</span>
-        <span class="material-symbols-rounded">keyboard_arrow_left</span>
+        <span class="material-symbols-rounded" aria-hidden="true">keyboard_arrow_left</span>
       </a>
     </li>
     <% end %>
@@ -22,7 +22,7 @@
     <li class="pagination-page">
       <a href="<%=pagination.next.url%>" class="pagination-page-link">
         <span class="visually-hidden">Next page</span>
-        <span class="material-symbols-rounded">keyboard_arrow_right</span>
+        <span class="material-symbols-rounded" aria-hidden="true">keyboard_arrow_right</span>
       </a>
     </li>
     <% end %>

--- a/views/current-checkouts/u-m-library.erb
+++ b/views/current-checkouts/u-m-library.erb
@@ -35,7 +35,7 @@
         <%= erb :'components/table_controls', locals: { table_controls: loan_controls} %>
         <div class="renew-all">
           <button class="button" data-js-renew-all="<%= loans.count %>" disabled>
-            <span class="material-symbols-rounded">autorenew</span> <span>Renew all eligible</span>
+            <span class="material-symbols-rounded" aria-hidden="true">autorenew</span> <span>Renew all eligible</span>
           </button>
         </div>
       </div>

--- a/views/current-checkouts/u-m-library.erb
+++ b/views/current-checkouts/u-m-library.erb
@@ -35,7 +35,7 @@
         <%= erb :'components/table_controls', locals: { table_controls: loan_controls} %>
         <div class="renew-all">
           <button class="button" data-js-renew-all="<%= loans.count %>" disabled>
-            <span class="material-symbols-rounded" aria-hidden="true">autorenew</span> <span>Renew all eligible</span>
+            <span class="material-symbols-rounded">autorenew</span> <span>Renew all eligible</span>
           </button>
         </div>
       </div>

--- a/views/fines-and-fees/index.erb
+++ b/views/fines-and-fees/index.erb
@@ -49,8 +49,8 @@
             value="true"
           >
           <label for="pay-all">
-            <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-            <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+            <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+            <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
             <span>Pay full amount (<span class="strong">$<%=fines.total_sum_in_dollars%></span>)</span>
           </label>
         </div>
@@ -63,8 +63,8 @@
             value="false"
           >
           <label for="pay-some">
-            <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-            <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+            <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+            <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
             <span>Pay partial amount</span>
           </label>
           <div id="pay-some-amount" class="radio-option-extra">
@@ -83,7 +83,7 @@
               autocomplete="off"
             >
             <div id="payment-description" class="input-description">
-              <span class="material-symbols-rounded">info</span>
+              <span class="material-symbols-rounded" aria-hidden="true">info</span>
               <span>Payment amount must include cents. Example:&nbsp;25.00</span>
             </div>
           </div>

--- a/views/layout/banner.erb
+++ b/views/layout/banner.erb
@@ -1,7 +1,7 @@
 <% if session[:confirmed_history_setting] == false %>
   <section class="banner">
     <div class="layout">
-      <p><span class="material-symbols-sharp">info</span> You have not yet specified whether you would like us to record your checkout history. You can update your preferences on the <a href="/settings">Settings</a> page.</p>
+      <p><span class="material-symbols-sharp" aria-hidden="true">info</span> You have not yet specified whether you would like us to record your checkout history. You can update your preferences on the <a href="/settings">Settings</a> page.</p>
     </div>
   </section>
 <% end %>

--- a/views/layout/horizontal_nav.erb
+++ b/views/layout/horizontal_nav.erb
@@ -6,7 +6,7 @@
 
 <% if home != page %>
   <p class="breadcrumbs">
-    <span class="material-symbols-rounded">keyboard_arrow_left</span>
+    <span class="material-symbols-rounded" aria-hidden="true">keyboard_arrow_left</span>
     <a href=<%=home.path%>>Back to <%=home.title%></a>
   </p>
 <% end %>

--- a/views/layout/navigation.erb
+++ b/views/layout/navigation.erb
@@ -6,7 +6,7 @@
       <% my_pages.pages.each do |page| %>
         <li class="<%= page.active %>">
           <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
-            <span class="material-symbols-rounded"><%=page.icon_name%></span><span><%=page.title%></span><%= erb :'components/open_in_new', locals: { title: page.title } %>
+            <span class="material-symbols-rounded" aria-hidden="true"><%=page.icon_name%></span><span><%=page.title%></span><%= erb :'components/open_in_new', locals: { title: page.title } %>
           </a>
         </li>
       <% end %>

--- a/views/layout/user_drop_down.erb
+++ b/views/layout/user_drop_down.erb
@@ -3,10 +3,10 @@
 <% if session[:uniqname] %>
   <nav class="user-navigation dropdown" aria-label="User Dropdown Navigation">
     <button aria-expanded="false" data-dropdown="user-nav-dropdown" class="button--dropdown">
-      <span class="material-symbols-sharp">person</span>
+      <span class="material-symbols-sharp" aria-hidden="true">person</span>
       <span class="username"><%=session[:uniqname]%></span>
-      <span class="material-symbols-rounded" style="display: block;">keyboard_arrow_down</span>
-      <span class="material-symbols-rounded" style="display: none;">keyboard_arrow_up</span>
+      <span class="material-symbols-rounded" style="display: block;" aria-hidden="true">keyboard_arrow_down</span>
+      <span class="material-symbols-rounded" style="display: none;" aria-hidden="true">keyboard_arrow_up</span>
     </button>
     <div class="navigation-lists dropdown-container" id="user-nav-dropdown" style="display: none;">
       <ul class="site-navigation-list">

--- a/views/settings/_modal.erb
+++ b/views/settings/_modal.erb
@@ -6,11 +6,11 @@
 >
   <div class="modal-container" role="dialog"  aria-labelledby="<%= modal[:id] %>-heading" aria-describedby="<%= modal[:id] %>-text">
     <button class="button--light button--close close-message" disabled>
-      <span class="material-symbols-rounded">close</span><span class="visually-hidden">Close</span>
+      <span class="material-symbols-rounded" aria-hidden="true">close</span><span class="visually-hidden">Close</span>
     </button>
     <% if modal[:state] %>
       <div class="modal-icon state-<%= modal[:state] %>">
-        <span class="material-symbols-rounded">warning</span>
+        <span class="material-symbols-rounded" aria-hidden="true">warning</span>
       </div>
     <% end %>
     <div class="modal-content owl">

--- a/views/settings/index.erb
+++ b/views/settings/index.erb
@@ -55,8 +55,8 @@
             <% if patron.sms_number? %>checked<% end%>
           >
           <label for="confirm-sms">
-            <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-            <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+            <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+            <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
             <span>Yes, please send me text notifications</span>
           </label>
           <div class="radio-option-extra">
@@ -73,7 +73,7 @@
               autocomplete="on"
             />
             <div id="sms-number-description" class="input-description">
-              <span class="material-symbols-rounded">info</span>
+              <span class="material-symbols-rounded" aria-hidden="true">info</span>
               <span>Phone number must be 10 digits. Acceptable formats are: (123)&nbsp;456&#8209;7890, 123&#8209;456&#8209;7890, and 1234567890.</span>
             </div>
           </div>
@@ -88,8 +88,8 @@
             <% if !patron.sms_number? %>checked<% end%>
           >
           <label for="deny-sms">
-            <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-            <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+            <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+            <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
             <span>No, do not send me text notifications</span>
           </label>
         </div>
@@ -115,8 +115,8 @@
           <% if patron.confirmed_history_setting? && patron.retain_history? %>checked<% end %>
         >
         <label for="opt-in">
-          <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-          <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+          <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+          <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
           <span>Yes, record my checkout history.</span>
         </label>
       </div>
@@ -130,8 +130,8 @@
           <% if patron.confirmed_history_setting? && !patron.retain_history? %>checked<% end %>
         >
         <label for="opt-out">
-          <span class="material-symbols-sharp radio-button-checked">radio_button_checked</span>
-          <span class="material-symbols-sharp radio-button-unchecked">radio_button_unchecked</span>
+          <span class="material-symbols-sharp radio-button-checked" aria-hidden="true">radio_button_checked</span>
+          <span class="material-symbols-sharp radio-button-unchecked" aria-hidden="true">radio_button_unchecked</span>
           <span>No, do not record my checkout history.</span>
         </label>
       </div>


### PR DESCRIPTION
# Overview
An [accessibility evaluation](https://docs.google.com/document/d/1mtfI-gPadsZ0gO2DME-kPrXKaZf2lFxapK6eWKw00Kk/edit) was done for [Account](https://account.lib.umich.edu/), and only one warning was discovered:
> The site uses [Material Symbol icons](https://fonts.google.com/icons?icon.set=Material+Symbols) in the markup and the icons are announced by the screen reader and use the material system names (e.g. keyboard_arrow_down).

To resolve this issue, all icons were given the attribute `aria-hidden="true"`. Whenever adding that, it creates warnings through ARC Toolkit.

This pull request closes [LIBSEARCH-896](https://mlit.atlassian.net/browse/LIBSEARCH-896).

## Testing
- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Use a screen reader (such as VoiceOver) to read through the site.
  - Do the icons still get announced?
  - Do you still see the icons?
