### PR TITLE
[LIBSEARCH-1077] ACCOUNT: remove redirect to apps.lib for favorites

### DIFF
--- a/account.rb
+++ b/account.rb
@@ -115,10 +115,6 @@ get "/" do
   erb :"account-overview/index", locals: {cards: Navigation.cards}
 end
 
-get "/favorites" do
-  redirect "https://apps.lib.umich.edu/my-account/favorites"
-end
-
 not_found do
   erb :empty_state
 end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -35,13 +35,6 @@ describe "requests" do
       expect(last_response.body).to include("Account Overview")
     end
   end
-  context "get /favorites" do
-    it "goes to olde favorites" do
-      get "/favorites"
-      expect(last_response.status).to eq(302)
-      expect(last_response.location).to eq("https://apps.lib.umich.edu/my-account/favorites")
-    end
-  end
   context "not_found" do
     it "shows page not found for not found" do
       get "/does_not_exist"

--- a/views/account-overview/index.erb
+++ b/views/account-overview/index.erb
@@ -4,7 +4,7 @@
       <a href="<%=card.slug%>" class="overview-card">
         <div>
           <h2 class="overview-card-heading">
-            <%=card.title%><%= erb :'components/open_in_new', locals: { title: card.title } %>
+            <%=card.title%>
           </h2>
           <p class="overview-card-description"><%=card.description%></p>
         </div>

--- a/views/components/open_in_new.erb
+++ b/views/components/open_in_new.erb
@@ -1,1 +1,0 @@
-<% if title == "Favorites" %><span class="material-symbols-rounded" aria-hidden="true">open_in_new</span><span class="visually-hidden">(link redirects to external site)</span><% end %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,7 +22,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
 
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,600,0..1,200&icon_names=attach_money,book,close,date_range,history,home,info,keyboard_arrow_down,keyboard_arrow_left,keyboard_arrow_right,open_in_new,person,settings,warning" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,600,0..1,200&icon_names=attach_money,book,close,date_range,history,home,info,keyboard_arrow_down,keyboard_arrow_left,keyboard_arrow_right,person,settings,warning" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/umich-lib.css" rel="stylesheet"/>
     <link href="/bundles/index.css" rel="stylesheet" />
 

--- a/views/layout/navigation.erb
+++ b/views/layout/navigation.erb
@@ -6,7 +6,7 @@
       <% my_pages.pages.each do |page| %>
         <li class="<%= page.active %>">
           <a href="<%=page.path%>" <% if page.active? %>aria-current="page"<% end %>>
-            <span class="material-symbols-rounded icon__filled" aria-hidden="true"><%=page.icon_name%></span><span><%=page.title%></span><%= erb :'components/open_in_new', locals: { title: page.title } %>
+            <span class="material-symbols-rounded icon__filled" aria-hidden="true"><%=page.icon_name%></span><span><%=page.title%></span>
           </a>
         </li>
       <% end %>


### PR DESCRIPTION
# Overview
> There’s still a redirect to apps.lib for favorites in the account codebase. It should be removed. 

The redirect and everything related to `Favorites` has been removed.

This pull request fixes [LIBSEARCH-1077](https://mlit.atlassian.net/browse/LIBSEARCH-1077).

## Testing
List instructions on how to test the pull request. Some examples:

- Run the tests to make sure they pass (`docker-compose run --rm web bundle exec rspec`).
  - Break the new/updated unit tests to make sure they're working properly.
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [x] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools
- Check if you can successfully navigate to `/favorites`. Should be a 404.
