### PR TITLE
dependabot tries to update ruby in March

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 multi-ecosystem-groups:
   app-dependencies:
     schedule:
@@ -9,40 +8,34 @@ multi-ecosystem-groups:
       timezone: "America/Detroit"
     commit-message:
       prefix: "Monthly dependency updates: "
-
   container-updates:
     schedule:
       interval: "cron"
-      cronjob: "0 6 3 4 *" #April 3 at 6AM
+      cronjob: "0 6 3 3 *" #March 3 at 6AM
       timezone: "America/Detroit"
     commit-message:
       prefix: "Annual container update: "
-
 updates:
   # For npm/JavaScript dependencies
   - package-ecosystem: "npm"
     directory: "/"
     multi-ecosystem-group: "app-dependencies"
     patterns: ["*"]
-
   # For GitHub Actions updates
   - package-ecosystem: "github-actions"
     directory: "/"
     multi-ecosystem-group: "app-dependencies"
     patterns: ["*"]
-
   # For Bundler/Ruby
   - package-ecosystem: "bundler"
     directory: "/"
     multi-ecosystem-group: "app-dependencies"
     patterns: ["*"]
-
   # For Docker
   - package-ecosystem: "docker"
     directory: "/"
     multi-ecosystem-group: "container-updates"
     patterns: ["*"]
-
   # For Docker Compose
   - package-ecosystem: "docker-compose"
     directory: "/"


### PR DESCRIPTION
We were updating the ruby version of the Dockerfile in April. March should be fine. 