### PR TITLE
Update alma rest client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+require: standard
+
+inherit_gem:
+  standard: config/base.yml

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "net-smtp", require: false
 
 gem "alma_rest_client",
   git: "https://github.com/mlibrary/alma_rest_client",
-  tag: "1.3.1"
+  tag: "alma_rest_client/v2.2.0"
 
 gem "yabeda-puma-plugin"
 gem "yabeda-prometheus"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,37 @@
 GIT
   remote: https://github.com/mlibrary/alma_rest_client
-  revision: 2014809367ece3f21935bd24b45a12285f61e253
-  tag: 1.3.1
+  revision: f94276a6e83d1526f7ec91c66aad1cee8b80f97d
+  tag: alma_rest_client/v2.2.0
   specs:
-    alma_rest_client (1.3.1)
-      activesupport (~> 7.0, >= 4.2)
-      httparty
+    alma_rest_client (2.2.0)
+      activesupport (~> 8.0)
+      faraday
+      faraday-retry
+      httpx
       rexml
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.2)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
     base64 (0.3.0)
-    benchmark (0.4.1)
     bigdecimal (4.1.0)
     canister (0.9.2)
     climate_control (1.2.0)
@@ -48,11 +50,22 @@ GEM
     drb (2.2.3)
     dry-initializer (3.2.0)
     erb (6.0.1)
+    faraday (2.14.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.3)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     hashdiff (1.2.1)
+    http-2 (1.1.3)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    httpx (1.7.8)
+      http-2 (>= 1.1.3)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -75,6 +88,8 @@ GEM
       bigdecimal (>= 3.1, < 5)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.1)
@@ -200,6 +215,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uri (1.1.1)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)

--- a/compose.yml
+++ b/compose.yml
@@ -12,9 +12,8 @@ services:
     env_file:
       - env.development
       - .env
-        
   circulation-history:
-    image: ghcr.io/mlibrary/circulation_history_unstable:latest
+    image: ghcr.io/mlibrary/checkout-history-unstable:latest
     ports:
       - "3000:3000"
     environment:
@@ -25,10 +24,8 @@ services:
       - SECRET_KEY_BASE=secret_key_base
     env_file:
       - .env
-
   circulation-history-db:
     image: ghcr.io/mlibrary/circulation_history_dev_db:latest
-
   sass:
     build:
       context: .
@@ -39,7 +36,6 @@ services:
       - ./package.json:/app/package.json
       - ./node_modules:/app/node_modules
     command: "npm run watch-css"
-
   esbuild:
     build:
       context: .
@@ -51,7 +47,6 @@ services:
       - ./node_modules:/app/node_modules
       - ./eslint.config.mjs:/app/eslint.config.mjs
     command: "npm run watch-js"
-
 volumes:
   gem_cache:
   circ_history_db:

--- a/lib/routes/pending_requests.rb
+++ b/lib/routes/pending_requests.rb
@@ -15,12 +15,12 @@ namespace "/pending-requests" do
   end
   post "/u-m-library/cancel-request" do
     response = Request.cancel(uniqname: session[:uniqname], request_id: params["request_id"])
-    if response.code == 204
+    if response.status == 204
       status 200
       {}.to_json
     else
       error = AlmaError.new(response)
-      status error.code
+      status error.status
       {message: error.message}.to_json
     end
   rescue

--- a/lib/routes/settings.rb
+++ b/lib/routes/settings.rb
@@ -18,7 +18,7 @@ end
 post "/sms" do
   patron = Patron.for(uniqname: session[:uniqname])
   response = patron.update_sms((params["text-notifications"] == "on") ? params["sms-number"] : "")
-  if response.code == 200
+  if response.status == 200
     flash[:success] = if params["text-notifications"] == "on"
       "<span class='strong'>Success:</span> Your SMS number was successfully updated"
     else

--- a/models/fines/fines.rb
+++ b/models/fines/fines.rb
@@ -1,4 +1,11 @@
 class Fines
+  def self.for(uniqname:, client: AlmaRestClient.client)
+    url = "/users/#{uniqname}/fees"
+    response = client.get_all(url: url, record_key: "fee")
+    raise StandardError if response.status != 200
+    Fines.new(parsed_response: response.body)
+  end
+
   def initialize(parsed_response:)
     @parsed_response = parsed_response
     @list = parsed_response["fee"]&.map { |l| Fine.new(l) } || []
@@ -39,27 +46,20 @@ class Fines
   def self.verify_payment(uniqname:, order_number:, client: AlmaRestClient.client)
     url = "/users/#{uniqname}/fees"
     response = client.get_all(url: url, record_key: "fee")
-    if response.code == 200
-      parsed_response = response.parsed_response
-      transactions = parsed_response["fee"].filter_map do |fee|
+    if response.status == 200
+      body = response.body
+      transactions = body["fee"].filter_map do |fee|
         fee["transaction"]
       end.flatten
       has_order_number = transactions.any? { |transaction| transaction["external_transaction_id"] == order_number }
       {
         has_order_number: has_order_number,
-        total_sum: parsed_response["total_sum"]
+        total_sum: body["total_sum"]
       }
     else
       # if this errors out return alma error
       AlmaError.new(response)
     end
-  end
-
-  def self.for(uniqname:, client: AlmaRestClient.client)
-    url = "/users/#{uniqname}/fees"
-    response = client.get_all(url: url, record_key: "fee")
-    raise StandardError if response.code != 200
-    Fines.new(parsed_response: response.parsed_response)
   end
 end
 

--- a/models/fines/fines.rb
+++ b/models/fines/fines.rb
@@ -3,12 +3,12 @@ class Fines
     url = "/users/#{uniqname}/fees"
     response = client.get_all(url: url, record_key: "fee")
     raise StandardError if response.status != 200
-    Fines.new(parsed_response: response.body)
+    Fines.new(body: response.body)
   end
 
-  def initialize(parsed_response:)
-    @parsed_response = parsed_response
-    @list = parsed_response["fee"]&.map { |l| Fine.new(l) } || []
+  def initialize(body:)
+    @body = body
+    @list = @body["fee"]&.map { |l| Fine.new(l) } || []
   end
 
   def self.pay(uniqname:, amount:, order_number:, client: AlmaRestClient.client)
@@ -16,11 +16,11 @@ class Fines
   end
 
   def count
-    @parsed_response["total_record_count"] || 0
+    @body["total_record_count"] || 0
   end
 
   def total_sum
-    @parsed_response["total_sum"] || 0
+    @body["total_sum"] || 0
   end
 
   def total_sum_in_dollars
@@ -64,8 +64,8 @@ class Fines
 end
 
 class Fine
-  def initialize(parsed_response)
-    @parsed_response = parsed_response
+  def initialize(body)
+    @body = body
   end
 
   def self.pay(uniqname:, fine_id:, balance:, client: AlmaRestClient.client)
@@ -74,38 +74,38 @@ class Fine
   end
 
   def id
-    @parsed_response["id"]
+    @body["id"]
   end
 
   def title
-    @parsed_response["title"]
+    @body["title"]
   end
 
   def barcode
-    @parsed_response.dig("barcode", "value")
+    @body.dig("barcode", "value")
   end
 
   def date
-    DateTime.patron_format(@parsed_response["creation_time"])
+    DateTime.patron_format(@body["creation_time"])
   end
 
   def balance
-    @parsed_response["balance"]&.to_currency
+    @body["balance"]&.to_currency
   end
 
   def type
-    @parsed_response["type"]["desc"]
+    @body["type"]["desc"]
   end
 
   def code
-    @parsed_response["type"]["value"]
+    @body["type"]["value"]
   end
 
   def original_amount
-    @parsed_response["original_amount"]&.to_currency
+    @body["original_amount"]&.to_currency
   end
 
   def library
-    @parsed_response["owner"]["desc"]
+    @body["owner"]["desc"]
   end
 end

--- a/models/fines/receipt.rb
+++ b/models/fines/receipt.rb
@@ -37,13 +37,13 @@ class Receipt
       ErrorReceipt.new("You do not have a balance. Your payment order number is: #{order_number}.")
     else # has not already paid
       resp = Fines.pay(uniqname: uniqname, amount: payment.amount, order_number: order_number)
-      if resp.code != 200
+      if resp.status != 200
         error = AlmaError.new(resp)
         S.logger.error("fine_payment_error", message: "Failed to apply payment to Alma: #{error.message}", **error_params)
         ErrorReceipt.new("#{error.message}<br>Your payment order number is: #{order_number}")
       else
         S.logger.info("fine_payment_success", message: "Fine payment success", order_number: order_number)
-        Receipt.new(payment: payment, balance: resp.parsed_response["total_sum"])
+        Receipt.new(payment: payment, balance: resp.body["total_sum"])
       end
     end
   end

--- a/models/illiad_patron.rb
+++ b/models/illiad_patron.rb
@@ -1,6 +1,6 @@
 class ILLiadPatron
-  def initialize(parsed_response)
-    @parsed_response = parsed_response
+  def initialize(body)
+    @body = body
   end
 
   def self.for(uniqname:, illiad_client: ILLiadClient.new)
@@ -16,7 +16,7 @@ class ILLiadPatron
   end
 
   def delivery_location
-    [@parsed_response["SAddress"], @parsed_response["SAddress2"]].reject { |x| x.nil? }.join(" / ")
+    [@body["SAddress"], @body["SAddress2"]].reject { |x| x.nil? }.join(" / ")
   end
 end
 

--- a/models/items/alma/alma_item.rb
+++ b/models/items/alma/alma_item.rb
@@ -1,5 +1,5 @@
 class AlmaItem < Item
   def url
-    "https://search.lib.umich.edu/catalog/record/#{@parsed_response["mms_id"]}"
+    "https://search.lib.umich.edu/catalog/record/#{@body["mms_id"]}"
   end
 end

--- a/models/items/alma/loans.rb
+++ b/models/items/alma/loans.rb
@@ -8,38 +8,6 @@ class Loans < Items
     @pagination = pagination
   end
 
-  # def self.renew_all(uniqname:, client: AlmaRestClient.client, connections: [],
-  # publisher: Publisher.new)
-  # url = "/users/#{uniqname}/loans"
-  # publisher.publish({step: 1, count: 0, renewed: 0, uniqname: uniqname})
-  # response = client.get_all(url: url, record_key: "item_loan", query: {"expand" => "renewable"})
-
-  # return response if response.status != 200
-  # loans = response.body["item_loan"]&.map do |loan|
-  # Loan.new(loan)
-  # end
-  # renew(uniqname: uniqname, loans: loans, publisher: publisher)
-  # end
-
-  # def self.renew(uniqname:, loans:, publisher: Publisher.new)
-  # count = 0
-  # renewed = 0
-  # renew_statuses = []
-  # loans.filter { |x| x.renewable? }.each do |loan|
-  # response = Loan.renew(uniqname: uniqname, loan_id: loan.loan_id)
-  # if response.code != 200
-  # renew_statuses.push(:fail)
-  # else
-  # renewed += 1
-  # renew_statuses.push(:success)
-  # end
-  # count += 1
-  # publisher.publish({step: 2, count: count, renewed: renewed, uniqname: uniqname})
-  # end
-  # publisher.publish({step: 3, count: count, renewed: renewed, uniqname: uniqname})
-  # RenewResponse.new(renew_statuses: renew_statuses)
-  # end
-
   def count
     @parsed_response["total_record_count"]
   end

--- a/models/items/alma/loans.rb
+++ b/models/items/alma/loans.rb
@@ -1,15 +1,15 @@
 class Loans < Items
   attr_reader :pagination
-  def initialize(parsed_response:, pagination:)
-    @parsed_response = parsed_response
-    @items = parsed_response["item_loan"]&.map do |loan|
+  def initialize(body:, pagination:)
+    @body = body
+    @items = @body["item_loan"]&.map do |loan|
       Loan.new(loan)
     end || []
     @pagination = pagination
   end
 
   def count
-    @parsed_response["total_record_count"]
+    @body["total_record_count"]
   end
 
   def self.for(uniqname:, offset: nil, limit: 15,
@@ -24,13 +24,13 @@ class Loans < Items
 
     response = client.get(url, query: query)
     raise StandardError unless response.status == 200
-    pr = response.body
-    pagination_params = {url: "/current-checkouts/u-m-library", total: pr["total_record_count"]}
+    body = response.body
+    pagination_params = {url: "/current-checkouts/u-m-library", total: body["total_record_count"]}
     pagination_params[:limit] = limit unless limit.nil?
     pagination_params[:current_offset] = offset unless offset.nil?
     pagination_params[:order_by] = order_by unless order_by.nil?
     pagination_params[:direction] = direction unless direction.nil?
-    Loans.new(parsed_response: pr, pagination: PaginationDecorator.new(**pagination_params))
+    Loans.new(body: body, pagination: PaginationDecorator.new(**pagination_params))
   end
 end
 
@@ -40,32 +40,28 @@ class Loan < AlmaItem
   end
 
   def due_date
-    DateTime.patron_format(@parsed_response["due_date"]) unless claims_returned?
-  end
-
-  def renewable?
-    !!@parsed_response["renewable"] # make this a real boolean
+    DateTime.patron_format(@body["due_date"]) unless claims_returned?
   end
 
   def loan_id
-    @parsed_response["loan_id"]
+    @body["loan_id"]
   end
 
   def call_number
-    @parsed_response["call_number"]
+    @body["call_number"]
   end
 
   def barcode
-    @parsed_response["item_barcode"]
+    @body["item_barcode"]
   end
 
   def publication_date
-    @parsed_response["publication_year"]
+    @body["publication_year"]
   end
 
   def due_status
     return OpenStruct.new(to_s: "Reported as returned", tag: "tag--warning", any?: true) if claims_returned?
-    DueStatus.new(due_date: @parsed_response["due_date"], last_renew_date: @parsed_response["last_renew_date"])
+    DueStatus.new(due_date: @body["due_date"], last_renew_date: @body["last_renew_date"])
   end
 
   def due_status_tag
@@ -75,6 +71,6 @@ class Loan < AlmaItem
   private
 
   def claims_returned?
-    @parsed_response["process_status"] == "CLAIMED_RETURN"
+    @body["process_status"] == "CLAIMED_RETURN"
   end
 end

--- a/models/items/alma/loans.rb
+++ b/models/items/alma/loans.rb
@@ -8,37 +8,37 @@ class Loans < Items
     @pagination = pagination
   end
 
-  def self.renew_all(uniqname:, client: AlmaRestClient.client, connections: [],
-    publisher: Publisher.new)
-    url = "/users/#{uniqname}/loans"
-    publisher.publish({step: 1, count: 0, renewed: 0, uniqname: uniqname})
-    response = client.get_all(url: url, record_key: "item_loan", query: {"expand" => "renewable"})
+  # def self.renew_all(uniqname:, client: AlmaRestClient.client, connections: [],
+  # publisher: Publisher.new)
+  # url = "/users/#{uniqname}/loans"
+  # publisher.publish({step: 1, count: 0, renewed: 0, uniqname: uniqname})
+  # response = client.get_all(url: url, record_key: "item_loan", query: {"expand" => "renewable"})
 
-    return response if response.code != 200
-    loans = response.parsed_response["item_loan"]&.map do |loan|
-      Loan.new(loan)
-    end
-    renew(uniqname: uniqname, loans: loans, publisher: publisher)
-  end
+  # return response if response.status != 200
+  # loans = response.body["item_loan"]&.map do |loan|
+  # Loan.new(loan)
+  # end
+  # renew(uniqname: uniqname, loans: loans, publisher: publisher)
+  # end
 
-  def self.renew(uniqname:, loans:, publisher: Publisher.new)
-    count = 0
-    renewed = 0
-    renew_statuses = []
-    loans.filter { |x| x.renewable? }.each do |loan|
-      response = Loan.renew(uniqname: uniqname, loan_id: loan.loan_id)
-      if response.code != 200
-        renew_statuses.push(:fail)
-      else
-        renewed += 1
-        renew_statuses.push(:success)
-      end
-      count += 1
-      publisher.publish({step: 2, count: count, renewed: renewed, uniqname: uniqname})
-    end
-    publisher.publish({step: 3, count: count, renewed: renewed, uniqname: uniqname})
-    RenewResponse.new(renew_statuses: renew_statuses)
-  end
+  # def self.renew(uniqname:, loans:, publisher: Publisher.new)
+  # count = 0
+  # renewed = 0
+  # renew_statuses = []
+  # loans.filter { |x| x.renewable? }.each do |loan|
+  # response = Loan.renew(uniqname: uniqname, loan_id: loan.loan_id)
+  # if response.code != 200
+  # renew_statuses.push(:fail)
+  # else
+  # renewed += 1
+  # renew_statuses.push(:success)
+  # end
+  # count += 1
+  # publisher.publish({step: 2, count: count, renewed: renewed, uniqname: uniqname})
+  # end
+  # publisher.publish({step: 3, count: count, renewed: renewed, uniqname: uniqname})
+  # RenewResponse.new(renew_statuses: renew_statuses)
+  # end
 
   def count
     @parsed_response["total_record_count"]
@@ -55,8 +55,8 @@ class Loans < Items
     query["limit"] = limit.nil? ? 15 : limit
 
     response = client.get(url, query: query)
-    raise StandardError unless response.code == 200
-    pr = response.parsed_response
+    raise StandardError unless response.status == 200
+    pr = response.body
     pagination_params = {url: "/current-checkouts/u-m-library", total: pr["total_record_count"]}
     pagination_params[:limit] = limit unless limit.nil?
     pagination_params[:current_offset] = offset unless offset.nil?

--- a/models/items/alma/requests.rb
+++ b/models/items/alma/requests.rb
@@ -13,8 +13,8 @@ class Requests
   def self.for(uniqname:, client: AlmaRestClient.client)
     url = "/users/#{uniqname}/requests"
     response = client.get_all(url: url, record_key: "user_request")
-    raise StandardError unless response.code == 200
-    Requests.new(parsed_response: response.parsed_response)
+    raise StandardError unless response.status == 200
+    Requests.new(parsed_response: response.body)
   end
 end
 

--- a/models/items/alma/requests.rb
+++ b/models/items/alma/requests.rb
@@ -1,20 +1,20 @@
 class Requests
   attr_reader :holds, :bookings
-  def initialize(parsed_response:)
-    @parsed_response = parsed_response
-    @holds = parsed_response["user_request"]&.select { |r| r["request_type"] == "HOLD" }&.map { |r| HoldRequest.new(r) } || []
-    @bookings = parsed_response["user_request"]&.select { |r| r["request_type"] == "BOOKING" }&.map { |r| BookingRequest.new(r) } || []
+  def initialize(body:)
+    @body = body
+    @holds = @body["user_request"]&.select { |r| r["request_type"] == "HOLD" }&.map { |r| HoldRequest.new(r) } || []
+    @bookings = @body["user_request"]&.select { |r| r["request_type"] == "BOOKING" }&.map { |r| BookingRequest.new(r) } || []
   end
 
   def count
-    @parsed_response["total_record_count"]
+    @body["total_record_count"]
   end
 
   def self.for(uniqname:, client: AlmaRestClient.client)
     url = "/users/#{uniqname}/requests"
     response = client.get_all(url: url, record_key: "user_request")
     raise StandardError unless response.status == 200
-    Requests.new(parsed_response: response.body)
+    Requests.new(body: response.body)
   end
 end
 
@@ -28,27 +28,27 @@ class Request < AlmaItem
   end
 
   def expiry_date
-    @parsed_response["expiry_date"] ? DateTime.patron_format(@parsed_response["expiry_date"]) : ""
+    @body["expiry_date"] ? DateTime.patron_format(@body["expiry_date"]) : ""
   end
 
   def publication_date
-    @parsed_response["date_of_publication"]
+    @body["date_of_publication"]
   end
 
   def request_id
-    @parsed_response["request_id"]
+    @body["request_id"]
   end
 
   def pickup_location
-    @parsed_response["pickup_location"]
+    @body["pickup_location"]
   end
 
   def request_date
-    DateTime.patron_format(@parsed_response["request_time"])
+    DateTime.patron_format(@body["request_time"])
   end
 
   def status
-    request_status = @parsed_response["request_status"] || ""
+    request_status = @body["request_status"] || ""
     normalized_status = request_status.upcase.tr(" ", "_")
     case normalized_status
     when "IN_PROCESS"
@@ -76,7 +76,7 @@ end
 
 class BookingRequest < Request
   def booking_date
-    DateTime.patron_format(@parsed_response["booking_start_date"])
+    DateTime.patron_format(@body["booking_start_date"])
   end
 
   def self.empty_state_text

--- a/models/items/circ_history/circ_history_item.rb
+++ b/models/items/circ_history/circ_history_item.rb
@@ -1,15 +1,15 @@
 class CirculationHistoryItems < Items
   attr_reader :pagination
-  def initialize(parsed_response:, pagination:)
-    @parsed_response = parsed_response
-    @items = parsed_response["loans"]&.map do |loan|
+  def initialize(body:, pagination:)
+    @body = body
+    @items = @body["loans"]&.map do |loan|
       CirculationHistoryItem.new(loan)
     end || []
     @pagination = pagination
   end
 
   def count
-    @parsed_response["total_record_count"]
+    @body["total_record_count"]
   end
 
   def self.for(uniqname:, offset: nil, limit: nil,
@@ -24,14 +24,14 @@ class CirculationHistoryItems < Items
 
     response = client.loans(query)
     if response.code == 200
-      pr = response.parsed_response
+      body = response.parsed_response
 
-      pagination_params = {url: "/past-activity/u-m-library", total: pr["total_record_count"]}
+      pagination_params = {url: "/past-activity/u-m-library", total: body["total_record_count"]}
       pagination_params[:limit] = limit unless limit.nil?
       pagination_params[:current_offset] = offset unless offset.nil?
       pagination_params[:order_by] = order_by unless order_by.nil?
       pagination_params[:direction] = direction.nil? ? "DESC" : direction
-      CirculationHistoryItems.new(parsed_response: pr, pagination: CirculationHistoryPaginationDecorator.new(**pagination_params))
+      CirculationHistoryItems.new(body: body, pagination: CirculationHistoryPaginationDecorator.new(**pagination_params))
     end
   end
 end
@@ -42,26 +42,26 @@ class CirculationHistoryItem < Item
   end
 
   def call_number
-    @parsed_response["call_number"]
+    @body["call_number"]
   end
 
   def barcode
-    @parsed_response["barcode"]
+    @body["barcode"]
   end
 
   def description
-    @parsed_response["description"]
+    @body["description"]
   end
 
   def checkout_date
-    DateTime.patron_format(@parsed_response["checkout_date"])
+    DateTime.patron_format(@body["checkout_date"])
   end
 
   def return_date
-    DateTime.patron_format(@parsed_response["return_date"])
+    DateTime.patron_format(@body["return_date"])
   end
 
   def mms_id
-    @parsed_response["mms_id"]
+    @body["mms_id"]
   end
 end

--- a/models/items/interlibrary_loan/document_delivery.rb
+++ b/models/items/interlibrary_loan/document_delivery.rb
@@ -1,8 +1,8 @@
 class DocumentDelivery < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| DocumentDeliveryItem.new(item) }
+    @items = body.map { |item| DocumentDeliveryItem.new(item) }
     @pagination = pagination
     @count = count
   end

--- a/models/items/interlibrary_loan/interlibrary_loan_item.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_item.rb
@@ -1,19 +1,19 @@
 class InterlibraryLoanItem < Item
-  def initialize(parsed_response)
+  def initialize(body)
     super
-    if @parsed_response["RequestType"] == "Article"
-      @title = [@parsed_response["PhotoJournalTitle"], @parsed_response["PhotoArticleTitle"]].reject { |e| e.to_s.empty? }.join(": ")
-      @author = [@parsed_response["PhotoArticleAuthor"], @parsed_response["PhotoItemAuthor"]].reject { |e| e.to_s.empty? }.join("; ")
-      @description = (!@parsed_response["PhotoJournalVolume"].nil?) ? "vol #{@parsed_response["PhotoJournalVolume"]}" : ""
+    if @body["RequestType"] == "Article"
+      @title = [@body["PhotoJournalTitle"], @body["PhotoArticleTitle"]].reject { |e| e.to_s.empty? }.join(": ")
+      @author = [@body["PhotoArticleAuthor"], @body["PhotoItemAuthor"]].reject { |e| e.to_s.empty? }.join("; ")
+      @description = (!@body["PhotoJournalVolume"].nil?) ? "vol #{@body["PhotoJournalVolume"]}" : ""
     else
-      @title = @parsed_response["LoanTitle"] || ""
-      @author = @parsed_response["LoanAuthor"] || ""
+      @title = @body["LoanTitle"] || ""
+      @author = @body["LoanAuthor"] || ""
       @description = ""
     end
   end
 
   def illiad_id
-    @parsed_response["TransactionNumber"]
+    @body["TransactionNumber"]
   end
 
   def illiad_url(action, form, type = false)
@@ -41,22 +41,22 @@ class InterlibraryLoanItem < Item
   end
 
   def creation_date
-    @parsed_response["CreationDate"] ? DateTime.patron_format(@parsed_response["CreationDate"]) : ""
+    @body["CreationDate"] ? DateTime.patron_format(@body["CreationDate"]) : ""
   end
 
   def expiration_date
-    @parsed_response["DueDate"] ? DateTime.patron_format(@parsed_response["DueDate"]) : ""
+    @body["DueDate"] ? DateTime.patron_format(@body["DueDate"]) : ""
   end
 
   def due_status
-    @parsed_response["DueDate"] ? DueStatus.new(due_date: @parsed_response["DueDate"]) : OpenStruct.new(any?: false)
+    @body["DueDate"] ? DueStatus.new(due_date: @body["DueDate"]) : OpenStruct.new(any?: false)
   end
 
   def transaction_date
-    @parsed_response["TransactionDate"] ? DateTime.patron_format(@parsed_response["TransactionDate"]) : ""
+    @body["TransactionDate"] ? DateTime.patron_format(@body["TransactionDate"]) : ""
   end
 
   def renewable?
-    @parsed_response["RenewalsAllowed"]
+    @body["RenewalsAllowed"]
   end
 end

--- a/models/items/interlibrary_loan/interlibrary_loan_items.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_items.rb
@@ -8,7 +8,7 @@ class InterlibraryLoanItems < Items
     body = response.parsed_response
     pagination_params = {url: url, total: ill_count.total(body)}.merge(ill_count.pagination_params)
 
-    new(parsed_response: ill_count.page_of_results(body), pagination: PaginationDecorator.new(**pagination_params), count: ill_count.total(body))
+    new(body: ill_count.page_of_results(body), pagination: PaginationDecorator.new(**pagination_params), count: ill_count.total(body))
   end
 
   def self.base_query

--- a/models/items/interlibrary_loan/interlibrary_loan_requests.rb
+++ b/models/items/interlibrary_loan/interlibrary_loan_requests.rb
@@ -1,8 +1,8 @@
 class InterlibraryLoanRequests < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| InterlibraryLoanRequest.new(item) }
+    @items = body.map { |item| InterlibraryLoanRequest.new(item) }
     @pagination = pagination
     @count = count
   end

--- a/models/items/interlibrary_loan/interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/interlibrary_loans.rb
@@ -1,8 +1,8 @@
 class InterlibraryLoans < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| InterlibraryLoan.new(item) }
+    @items = body.map { |item| InterlibraryLoan.new(item) }
     @pagination = pagination
     @count = count
   end

--- a/models/items/interlibrary_loan/past_document_delivery.rb
+++ b/models/items/interlibrary_loan/past_document_delivery.rb
@@ -1,8 +1,8 @@
 class PastDocumentDelivery < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| PastDocumentDeliveryItem.new(item) }
+    @items = body.map { |item| PastDocumentDeliveryItem.new(item) }
     @pagination = pagination
     @count = count
   end

--- a/models/items/interlibrary_loan/past_interlibrary_loans.rb
+++ b/models/items/interlibrary_loan/past_interlibrary_loans.rb
@@ -1,8 +1,8 @@
 class PastInterlibraryLoans < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| PastInterlibraryLoan.new(item) }
+    @items = body.map { |item| PastInterlibraryLoan.new(item) }
     @pagination = pagination
     @count = count
   end

--- a/models/items/interlibrary_loan/pending_document_delivery.rb
+++ b/models/items/interlibrary_loan/pending_document_delivery.rb
@@ -1,8 +1,8 @@
 class PendingLocalDocumentDelivery < InterlibraryLoanItems
   attr_reader :pagination, :count
-  def initialize(parsed_response:, pagination:, count: nil)
+  def initialize(pagination:, body:, count: nil)
     super
-    @items = parsed_response.map { |item| PendingDocumentDeliveryItem.new(item) }
+    @items = body.map { |item| PendingDocumentDeliveryItem.new(item) }
     @pagination = pagination
     @count = count
   end
@@ -26,7 +26,7 @@ end
 
 class PendingDocumentDeliveryItem < InterlibraryLoanItem
   def status
-    tstatus = @parsed_response["TransactionStatus"]
+    tstatus = @body["TransactionStatus"]
     if ["In Delivery Transit", "Out for Delivery"].include?(tstatus)
       "Being delivered"
     elsif ["Customer Notified via E-Mail"].include?(tstatus)

--- a/models/items/item.rb
+++ b/models/items/item.rb
@@ -1,7 +1,6 @@
 class Item
-  attr_reader :parsed_response, :description
+  attr_reader :description, :body
   def initialize(body)
-    @parsed_response = body
     @body = body
     @author = @body["author"] || ""
     @title = @body["title"] || ""

--- a/models/items/item.rb
+++ b/models/items/item.rb
@@ -1,10 +1,11 @@
 class Item
   attr_reader :parsed_response, :description
-  def initialize(parsed_response)
-    @parsed_response = parsed_response
-    @author = @parsed_response["author"] || ""
-    @title = @parsed_response["title"] || ""
-    @description = @parsed_response["description"] || ""
+  def initialize(body)
+    @parsed_response = body
+    @body = body
+    @author = @body["author"] || ""
+    @title = @body["title"] || ""
+    @description = @body["description"] || ""
   end
 
   def title

--- a/models/items/items.rb
+++ b/models/items/items.rb
@@ -1,6 +1,6 @@
 class Items
-  def initialize(parsed_response)
-    @parsed_response = parsed_response
+  def initialize(body)
+    @body = body
     @items = []
   end
 

--- a/models/patron.rb
+++ b/models/patron.rb
@@ -18,8 +18,8 @@ class Patron
       circ_history_data = {"confirmed" => false, "retain_history" => false}
     end
 
-    if alma_response.code == 200
-      Patron.new(alma_data: alma_response.parsed_response, circ_history_data: circ_history_data, illiad_data: illiad_data)
+    if alma_response.status == 200
+      Patron.new(alma_data: alma_response.body, circ_history_data: circ_history_data, illiad_data: illiad_data)
     else
       NotInAlma.new(uniqname, circ_history_data)
     end
@@ -61,7 +61,7 @@ class Patron
     return Error.new(message: "Phone number #{sms} is invalid") unless phone.valid? || sms.empty?
     url = "/users/#{uniqname}"
     response = client.put(url, body: patron_with_internal_sms(phone.national_number).to_json)
-    (response.code == 200) ? response : AlmaError.new(response)
+    (response.status == 200) ? response : AlmaError.new(response)
   end
 
   def uniqname

--- a/models/response/response.rb
+++ b/models/response/response.rb
@@ -1,11 +1,9 @@
 class Response
-  attr_reader :status, :code, :message, :parsed_response, :body
-  def initialize(code: 200, message: "Success", parsed_response: {})
-    @code = code
-    @status = code
+  attr_reader :status, :code, :message, :body
+  def initialize(status: 200, message: "Success", body: {})
+    @status = status
     @message = message
-    @parsed_response = parsed_response
-    @body = parsed_response
+    @body = body
   end
 end
 
@@ -21,7 +19,7 @@ end
 # end
 
 class Error < Response
-  def initialize(code: 500, message: "There was an error")
+  def initialize(status: 500, message: "There was an error")
     super
   end
 end
@@ -29,10 +27,7 @@ end
 class AlmaError < Error
   def initialize(response)
     @body = response.body
-    # TBDeleted
-    @parsed_response = response.body
     @status = response.status
-    @code = status
 
     @message = get_messages
   end

--- a/models/response/response.rb
+++ b/models/response/response.rb
@@ -1,22 +1,24 @@
 class Response
-  attr_reader :code, :message, :parsed_response
+  attr_reader :status, :code, :message, :parsed_response, :body
   def initialize(code: 200, message: "Success", parsed_response: {})
     @code = code
+    @status = code
     @message = message
     @parsed_response = parsed_response
+    @body = parsed_response
   end
 end
 
-class RenewResponse < Response
-  attr_reader :code, :renewed, :not_renewed, :messages, :renewed_count, :not_renewed_count
-  def initialize(code: 200, messages: [], renew_statuses: [])
-    @code = code
-    @messages = messages
-    @renew_statuses = renew_statuses
-    @renewed_count = @renew_statuses.count { |x| x == :success }
-    @not_renewed_count = @renew_statuses.count { |x| x == :fail }
-  end
-end
+# class RenewResponse < Response
+# attr_reader :code, :renewed, :not_renewed, :messages, :renewed_count, :not_renewed_count
+# def initialize(code: 200, messages: [], renew_statuses: [])
+# @code = code
+# @messages = messages
+# @renew_statuses = renew_statuses
+# @renewed_count = @renew_statuses.count { |x| x == :success }
+# @not_renewed_count = @renew_statuses.count { |x| x == :fail }
+# end
+# end
 
 class Error < Response
   def initialize(code: 500, message: "There was an error")
@@ -26,15 +28,19 @@ end
 
 class AlmaError < Error
   def initialize(response)
-    @parsed_response = response.parsed_response
-    @code = response.code
+    @body = response.body
+    # TBDeleted
+    @parsed_response = response.body
+    @status = response.status
+    @code = status
+
     @message = get_messages
   end
 
   private
 
   def get_messages
-    errors = @parsed_response.dig("errorList", "error")&.map { |x| x["errorMessage"].strip }
+    errors = @body.dig("errorList", "error")&.map { |x| x["errorMessage"].strip }
     message = errors&.join(" ") || ""
     message.to_s
   end

--- a/spec/models/fines/fines_spec.rb
+++ b/spec/models/fines/fines_spec.rb
@@ -39,8 +39,8 @@ describe Fines do
 end
 describe Fines, "self.pay" do
   it "posts to Alma with user fine info" do
-    stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, output: "Success")
-    expect(Fines.pay(uniqname: "jbister", amount: "5.00", order_number: "12345").body).to eq("Success")
+    stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, output: '{"result":"Success"}')
+    expect(Fines.pay(uniqname: "jbister", amount: "5.00", order_number: "12345").body).to eq({"result" => "Success"})
   end
 end
 
@@ -129,7 +129,7 @@ describe Fine do
 end
 describe Fine, "self.pay" do
   it "posts to Alma with user fine info" do
-    stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, output: "Success")
-    expect(Fine.pay(uniqname: "jbister", fine_id: "1234", balance: "1.00").body).to eq("Success")
+    stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, output: '{"result":"Success"}')
+    expect(Fine.pay(uniqname: "jbister", fine_id: "1234", balance: "1.00").body).to eq({"result" => "Success"})
   end
 end

--- a/spec/models/fines/fines_spec.rb
+++ b/spec/models/fines/fines_spec.rb
@@ -1,6 +1,6 @@
 describe Fines do
   before(:each) do
-    old_stub_alma_get_request(url: "users/jbister/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
+    stub_alma_get_request(url: "users/jbister/fees", output: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
   end
   subject do
     described_class.for(uniqname: "jbister")
@@ -39,7 +39,7 @@ describe Fines do
 end
 describe Fines, "self.pay" do
   it "posts to Alma with user fine info" do
-    old_stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, body: "Success")
+    stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, output: "Success")
     expect(Fines.pay(uniqname: "jbister", amount: "5.00", order_number: "12345").body).to eq("Success")
   end
 end
@@ -50,7 +50,7 @@ describe Fines, "self.verify_payment" do
     @order_number = "number_not_in_alma_response"
   end
   let(:stub_fee_request) {
-    old_stub_alma_get_request(url: "users/jbister/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    stub_alma_get_request(url: "users/jbister/fees", output: @fine_response.to_json, query: {limit: 100, offset: 0})
   }
   subject do
     described_class.verify_payment(uniqname: "jbister", order_number: @order_number)
@@ -65,7 +65,7 @@ describe Fines, "self.verify_payment" do
     expect(subject).to eq({has_order_number: false, total_sum: 25})
   end
   it "returns alma error if alma request fails" do
-    old_stub_alma_get_request(url: "users/jbister/fees", body: File.read("spec/fixtures/alma_error.json"), query: {limit: 100, offset: 0}, status: 500)
+    stub_alma_get_request(url: "users/jbister/fees", output: File.read("spec/fixtures/alma_error.json"), query: {limit: 100, offset: 0}, status: 500)
     expect(subject.class.name).to eq("AlmaError")
   end
 end
@@ -129,7 +129,7 @@ describe Fine do
 end
 describe Fine, "self.pay" do
   it "posts to Alma with user fine info" do
-    old_stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, body: "Success")
+    stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, output: "Success")
     expect(Fine.pay(uniqname: "jbister", fine_id: "1234", balance: "1.00").body).to eq("Success")
   end
 end

--- a/spec/models/fines/fines_spec.rb
+++ b/spec/models/fines/fines_spec.rb
@@ -1,6 +1,6 @@
 describe Fines do
   before(:each) do
-    stub_alma_get_request(url: "users/jbister/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
+    old_stub_alma_get_request(url: "users/jbister/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
   end
   subject do
     described_class.for(uniqname: "jbister")
@@ -39,7 +39,7 @@ describe Fines do
 end
 describe Fines, "self.pay" do
   it "posts to Alma with user fine info" do
-    stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, body: "Success")
+    old_stub_alma_post_request(url: "users/jbister/fees/all", query: {op: "pay", amount: "5.00", method: "ONLINE", external_transaction_id: "12345"}, body: "Success")
     expect(Fines.pay(uniqname: "jbister", amount: "5.00", order_number: "12345").body).to eq("Success")
   end
 end
@@ -50,7 +50,7 @@ describe Fines, "self.verify_payment" do
     @order_number = "number_not_in_alma_response"
   end
   let(:stub_fee_request) {
-    stub_alma_get_request(url: "users/jbister/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    old_stub_alma_get_request(url: "users/jbister/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
   }
   subject do
     described_class.verify_payment(uniqname: "jbister", order_number: @order_number)
@@ -65,7 +65,7 @@ describe Fines, "self.verify_payment" do
     expect(subject).to eq({has_order_number: false, total_sum: 25})
   end
   it "returns alma error if alma request fails" do
-    stub_alma_get_request(url: "users/jbister/fees", body: File.read("spec/fixtures/alma_error.json"), query: {limit: 100, offset: 0}, status: 500)
+    old_stub_alma_get_request(url: "users/jbister/fees", body: File.read("spec/fixtures/alma_error.json"), query: {limit: 100, offset: 0}, status: 500)
     expect(subject.class.name).to eq("AlmaError")
   end
 end
@@ -129,7 +129,7 @@ describe Fine do
 end
 describe Fine, "self.pay" do
   it "posts to Alma with user fine info" do
-    stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, body: "Success")
+    old_stub_alma_post_request(url: "users/jbister/fees/1234", query: {op: "pay", amount: "1.00", method: "ONLINE"}, body: "Success")
     expect(Fine.pay(uniqname: "jbister", fine_id: "1234", balance: "1.00").body).to eq("Success")
   end
 end

--- a/spec/models/fines/receipt_spec.rb
+++ b/spec/models/fines/receipt_spec.rb
@@ -30,20 +30,20 @@ describe Receipt, ".for" do
     @fine_payment_response = JSON.parse(File.read("spec/fixtures/fines_pay_amount.json"))
     @fine_response = JSON.parse(File.read("spec/fixtures/jbister_fines.json"))
     @is_valid = true
-    stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    old_stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
   end
   let(:alma_error) { File.read("spec/fixtures/alma_error.json") }
   subject do
     described_class.for(uniqname: "tutor", nelnet_params: @params, order_number: @order_number, is_valid: @is_valid)
   end
   it "returns full receipt if alma update goes through" do
-    stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: @fine_payment_response.to_json)
+    old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: @fine_payment_response.to_json)
     expect(subject.balance).to eq("15.00")
     expect(subject.order_number).to eq(@order_number)
     expect(subject.successful?).to eq(true)
   end
   it "returns an ErrorReceipt with error messages for failed Alma Update" do
-    stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: alma_error, status: 500)
+    old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: alma_error, status: 500)
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("User with identifier mrioaaa was not found.")
     expect(subject.successful?).to eq(false)
@@ -54,7 +54,7 @@ describe Receipt, ".for" do
     expect(subject.message).to include("could not be validated")
   end
   it "returns ErrorReceipt for problem in getting alma verification" do
-    stub_alma_get_request(url: "users/tutor/fees", body: alma_error, query: {limit: 100, offset: 0}, status: 500)
+    old_stub_alma_get_request(url: "users/tutor/fees", body: alma_error, query: {limit: 100, offset: 0}, status: 500)
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("There was an error")
   end
@@ -65,7 +65,7 @@ describe Receipt, ".for" do
   end
   it "returns ErrorReceipt if balance in Alma is 0" do
     @fine_response["total_sum"] = "0"
-    stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    old_stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("balance")
   end

--- a/spec/models/fines/receipt_spec.rb
+++ b/spec/models/fines/receipt_spec.rb
@@ -30,20 +30,20 @@ describe Receipt, ".for" do
     @fine_payment_response = JSON.parse(File.read("spec/fixtures/fines_pay_amount.json"))
     @fine_response = JSON.parse(File.read("spec/fixtures/jbister_fines.json"))
     @is_valid = true
-    old_stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    stub_alma_get_request(url: "users/tutor/fees", output: @fine_response.to_json, query: {limit: 100, offset: 0})
   end
   let(:alma_error) { File.read("spec/fixtures/alma_error.json") }
   subject do
     described_class.for(uniqname: "tutor", nelnet_params: @params, order_number: @order_number, is_valid: @is_valid)
   end
   it "returns full receipt if alma update goes through" do
-    old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: @fine_payment_response.to_json)
+    stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, output: @fine_payment_response.to_json)
     expect(subject.balance).to eq("15.00")
     expect(subject.order_number).to eq(@order_number)
     expect(subject.successful?).to eq(true)
   end
   it "returns an ErrorReceipt with error messages for failed Alma Update" do
-    old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, body: alma_error, status: 500)
+    stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", method: "ONLINE", amount: "22.50", external_transaction_id: @order_number}, output: alma_error, status: 500)
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("User with identifier mrioaaa was not found.")
     expect(subject.successful?).to eq(false)
@@ -54,7 +54,7 @@ describe Receipt, ".for" do
     expect(subject.message).to include("could not be validated")
   end
   it "returns ErrorReceipt for problem in getting alma verification" do
-    old_stub_alma_get_request(url: "users/tutor/fees", body: alma_error, query: {limit: 100, offset: 0}, status: 500)
+    stub_alma_get_request(url: "users/tutor/fees", output: alma_error, query: {limit: 100, offset: 0}, status: 500)
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("There was an error")
   end
@@ -65,7 +65,7 @@ describe Receipt, ".for" do
   end
   it "returns ErrorReceipt if balance in Alma is 0" do
     @fine_response["total_sum"] = "0"
-    old_stub_alma_get_request(url: "users/tutor/fees", body: @fine_response.to_json, query: {limit: 100, offset: 0})
+    stub_alma_get_request(url: "users/tutor/fees", output: @fine_response.to_json, query: {limit: 100, offset: 0})
     expect(subject.class.name).to eq("ErrorReceipt")
     expect(subject.message).to include("balance")
   end

--- a/spec/models/items/alma/loans_spec.rb
+++ b/spec/models/items/alma/loans_spec.rb
@@ -4,7 +4,7 @@ require "json"
 describe Loans do
   context "two loans" do
     before(:each) do
-      stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
+      old_stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister")
@@ -31,7 +31,7 @@ describe Loans do
   end
   context "no loans" do
     before(:each) do
-      stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/no_loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
+      old_stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/no_loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister")
@@ -53,7 +53,7 @@ describe Loans do
       @loan = one_loan["item_loan"].delete_at(0).to_json
     end
     it "requests loans sorted by title" do
-      stub_alma_get_request(url: "users/jbister/loans", body: @loan, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "direction" => "DESC", "order_by" => "title"})
+      old_stub_alma_get_request(url: "users/jbister/loans", body: @loan, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "direction" => "DESC", "order_by" => "title"})
       loans = Loans.for(uniqname: "jbister", offset: 1, limit: 1, direction: "DESC", order_by: "title")
       expect(loans.pagination.next.url).to include("direction=DESC")
       expect(loans.pagination.next.url).to include("order_by=title")
@@ -64,7 +64,7 @@ describe Loans do
     before(:each) do
       one_loan = JSON.parse(File.read("./spec/fixtures/loans.json"))
       one_loan["item_loan"].delete_at(0)
-      stub_alma_get_request(url: "users/jbister/loans", body: one_loan.to_json, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "order_by" => "due_date"})
+      old_stub_alma_get_request(url: "users/jbister/loans", body: one_loan.to_json, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "order_by" => "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister", offset: 1, limit: 1)

--- a/spec/models/items/alma/loans_spec.rb
+++ b/spec/models/items/alma/loans_spec.rb
@@ -4,7 +4,7 @@ require "json"
 describe Loans do
   context "two loans" do
     before(:each) do
-      old_stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
+      stub_alma_get_request(url: "users/jbister/loans", output: File.read("./spec/fixtures/loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister")
@@ -31,7 +31,7 @@ describe Loans do
   end
   context "no loans" do
     before(:each) do
-      old_stub_alma_get_request(url: "users/jbister/loans", body: File.read("./spec/fixtures/no_loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
+      stub_alma_get_request(url: "users/jbister/loans", output: File.read("./spec/fixtures/no_loans.json"), query: {expand: "renewable", limit: 15, order_by: "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister")
@@ -53,7 +53,7 @@ describe Loans do
       @loan = one_loan["item_loan"].delete_at(0).to_json
     end
     it "requests loans sorted by title" do
-      old_stub_alma_get_request(url: "users/jbister/loans", body: @loan, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "direction" => "DESC", "order_by" => "title"})
+      stub_alma_get_request(url: "users/jbister/loans", output: @loan, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "direction" => "DESC", "order_by" => "title"})
       loans = Loans.for(uniqname: "jbister", offset: 1, limit: 1, direction: "DESC", order_by: "title")
       expect(loans.pagination.next.url).to include("direction=DESC")
       expect(loans.pagination.next.url).to include("order_by=title")
@@ -64,7 +64,7 @@ describe Loans do
     before(:each) do
       one_loan = JSON.parse(File.read("./spec/fixtures/loans.json"))
       one_loan["item_loan"].delete_at(0)
-      old_stub_alma_get_request(url: "users/jbister/loans", body: one_loan.to_json, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "order_by" => "due_date"})
+      stub_alma_get_request(url: "users/jbister/loans", output: one_loan.to_json, query: {"expand" => "renewable", "offset" => 1, "limit" => 1, "order_by" => "due_date"})
     end
     subject do
       Loans.for(uniqname: "jbister", offset: 1, limit: 1)

--- a/spec/models/items/alma/requests_spec.rb
+++ b/spec/models/items/alma/requests_spec.rb
@@ -3,7 +3,7 @@ require "json"
 
 describe Requests do
   before(:each) do
-    stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
+    old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
   end
   subject do
     Requests.for(uniqname: "tutor")
@@ -47,11 +47,11 @@ describe Request, ".cancel(request_id:, uniqname:)" do
     described_class.cancel(request_id: "1234", uniqname: "jbister")
   end
   it "properly cancels a request in alma" do
-    stub_alma_delete_request(url: "users/jbister/requests/1234", body: "{}", query: {reason: "CancelledAtPatronRequest"})
+    old_stub_alma_delete_request(url: "users/jbister/requests/1234", body: "{}", query: {reason: "CancelledAtPatronRequest"})
     expect(subject.code).to eq(200)
   end
   it "returns response from alma on failed cancelation request" do
-    stub_alma_delete_request(url: "users/jbister/requests/1234", body: File.read("./spec/fixtures/alma_error.json"), query: {reason: "CancelledAtPatronRequest"}, status: 400)
+    old_stub_alma_delete_request(url: "users/jbister/requests/1234", body: File.read("./spec/fixtures/alma_error.json"), query: {reason: "CancelledAtPatronRequest"}, status: 400)
     expect(subject.code).to eq(400)
   end
 end

--- a/spec/models/items/alma/requests_spec.rb
+++ b/spec/models/items/alma/requests_spec.rb
@@ -3,7 +3,7 @@ require "json"
 
 describe Requests do
   before(:each) do
-    old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
+    stub_alma_get_request(url: "users/tutor/requests", output: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
   end
   subject do
     Requests.for(uniqname: "tutor")
@@ -47,11 +47,11 @@ describe Request, ".cancel(request_id:, uniqname:)" do
     described_class.cancel(request_id: "1234", uniqname: "jbister")
   end
   it "properly cancels a request in alma" do
-    old_stub_alma_delete_request(url: "users/jbister/requests/1234", body: "{}", query: {reason: "CancelledAtPatronRequest"})
+    stub_alma_delete_request(url: "users/jbister/requests/1234", output: "{}", query: {reason: "CancelledAtPatronRequest"})
     expect(subject.code).to eq(200)
   end
   it "returns response from alma on failed cancelation request" do
-    old_stub_alma_delete_request(url: "users/jbister/requests/1234", body: File.read("./spec/fixtures/alma_error.json"), query: {reason: "CancelledAtPatronRequest"}, status: 400)
+    stub_alma_delete_request(url: "users/jbister/requests/1234", output: File.read("./spec/fixtures/alma_error.json"), query: {reason: "CancelledAtPatronRequest"}, status: 400)
     expect(subject.code).to eq(400)
   end
 end

--- a/spec/models/items/alma/requests_spec.rb
+++ b/spec/models/items/alma/requests_spec.rb
@@ -48,11 +48,11 @@ describe Request, ".cancel(request_id:, uniqname:)" do
   end
   it "properly cancels a request in alma" do
     stub_alma_delete_request(url: "users/jbister/requests/1234", output: "{}", query: {reason: "CancelledAtPatronRequest"})
-    expect(subject.code).to eq(200)
+    expect(subject.status).to eq(200)
   end
   it "returns response from alma on failed cancelation request" do
     stub_alma_delete_request(url: "users/jbister/requests/1234", output: File.read("./spec/fixtures/alma_error.json"), query: {reason: "CancelledAtPatronRequest"}, status: 400)
-    expect(subject.code).to eq(400)
+    expect(subject.status).to eq(400)
   end
 end
 describe HoldRequest do

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -10,7 +10,7 @@ describe Patron do
       @patron_url = "users/mrio?user_id_type=all_unique&view=full&expand=none"
     end
     subject do
-      stub_alma_get_request(
+      old_stub_alma_get_request(
         url: @patron_url,
         body: @alma_response.to_json
       )
@@ -29,7 +29,7 @@ describe Patron do
         @updated_patron = patron.to_json
       end
       it "returns status of 200 for sucessful update" do
-        stub_alma_put_request(
+        old_stub_alma_put_request(
           url: "users/mrio",
           input: @updated_patron,
           output: @updated_patron
@@ -37,7 +37,7 @@ describe Patron do
         expect(subject.update_sms(@new_phone).code).to eq(200)
       end
       it "returns alma error for failed update" do
-        stub_alma_put_request(
+        old_stub_alma_put_request(
           url: "users/mrio",
           input: @updated_patron,
           output: File.read("./spec/fixtures/alma_error.json"),
@@ -198,7 +198,7 @@ describe Patron do
       @alma_response = JSON.parse(File.read("./spec/fixtures/mrio_user_alma.json"))
       @circ_history_response = JSON.parse(File.read("./spec/fixtures/circ_history_user.json"))
       @patron_url = "users/mrio?user_id_type=all_unique&view=full&expand=none"
-      stub_alma_get_request(
+      old_stub_alma_get_request(
         url: @patron_url,
         body: @alma_response.to_json
       )
@@ -245,7 +245,7 @@ describe Patron do
     before(:each) do
       @alma_response = File.read("./spec/fixtures/alma_error.json")
       @patron_url = "users/mrioaaa?user_id_type=all_unique&view=full&expand=none"
-      stub_alma_get_request(
+      old_stub_alma_get_request(
         status: 400,
         url: @patron_url,
         body: @alma_response

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -10,9 +10,9 @@ describe Patron do
       @patron_url = "users/mrio?user_id_type=all_unique&view=full&expand=none"
     end
     subject do
-      old_stub_alma_get_request(
+      stub_alma_get_request(
         url: @patron_url,
-        body: @alma_response.to_json
+        output: @alma_response.to_json
       )
       stub_circ_history_get_request(
         url: "users/mrio",
@@ -29,7 +29,7 @@ describe Patron do
         @updated_patron = patron.to_json
       end
       it "returns status of 200 for sucessful update" do
-        old_stub_alma_put_request(
+        stub_alma_put_request(
           url: "users/mrio",
           input: @updated_patron,
           output: @updated_patron
@@ -37,7 +37,7 @@ describe Patron do
         expect(subject.update_sms(@new_phone).code).to eq(200)
       end
       it "returns alma error for failed update" do
-        old_stub_alma_put_request(
+        stub_alma_put_request(
           url: "users/mrio",
           input: @updated_patron,
           output: File.read("./spec/fixtures/alma_error.json"),
@@ -198,9 +198,9 @@ describe Patron do
       @alma_response = JSON.parse(File.read("./spec/fixtures/mrio_user_alma.json"))
       @circ_history_response = JSON.parse(File.read("./spec/fixtures/circ_history_user.json"))
       @patron_url = "users/mrio?user_id_type=all_unique&view=full&expand=none"
-      old_stub_alma_get_request(
+      stub_alma_get_request(
         url: @patron_url,
-        body: @alma_response.to_json
+        output: @alma_response.to_json
       )
       stub_illiad_get_request(url: "Users/mrio", status: 404)
       stub_circ_history_get_request(
@@ -245,10 +245,10 @@ describe Patron do
     before(:each) do
       @alma_response = File.read("./spec/fixtures/alma_error.json")
       @patron_url = "users/mrioaaa?user_id_type=all_unique&view=full&expand=none"
-      old_stub_alma_get_request(
+      stub_alma_get_request(
         status: 400,
         url: @patron_url,
-        body: @alma_response
+        output: @alma_response
       )
       stub_circ_history_get_request(
         url: "users/mrioaaa",

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -49,7 +49,7 @@ describe Patron do
       end
       it "rejects invalid phone number" do
         result = subject.update_sms("aaa1234")
-        expect(result.code).to eq(500)
+        expect(result.status).to eq(500)
         expect(result.message).to eq("Phone number aaa1234 is invalid")
       end
       it "submits internal phone number for non_existent number" do

--- a/spec/models/patron_spec.rb
+++ b/spec/models/patron_spec.rb
@@ -34,7 +34,7 @@ describe Patron do
           input: @updated_patron,
           output: @updated_patron
         )
-        expect(subject.update_sms(@new_phone).code).to eq(200)
+        expect(subject.update_sms(@new_phone).status).to eq(200)
       end
       it "returns alma error for failed update" do
         stub_alma_put_request(
@@ -44,7 +44,7 @@ describe Patron do
           status: 500
         )
         result = subject.update_sms(@new_phone)
-        expect(result.code).to eq(500)
+        expect(result.status).to eq(500)
         expect(result.message).to eq("User with identifier mrioaaa was not found.")
       end
       it "rejects invalid phone number" do
@@ -54,13 +54,13 @@ describe Patron do
       end
       it "submits internal phone number for non_existent number" do
         @alma_response["contact_info"]["phone"].delete_at(1)
-        response_dbl = double("response", code: 200)
+        response_dbl = double("response", status: 200)
         client_dbl = instance_double(AlmaRestClient::Client, put: response_dbl)
         expect(client_dbl).to receive(:put).with(anything, body: @updated_patron)
         subject.update_sms(@new_phone, client_dbl)
       end
       it "submits removed phone number when sent an empty number" do
-        response_dbl = double("response", code: 200)
+        response_dbl = double("response", status: 200)
         client_dbl = instance_double(AlmaRestClient::Client, put: response_dbl)
 
         expected_sent_data = JSON.parse(@alma_response.to_json)

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -15,7 +15,7 @@ describe "authentication requests" do
     }
   }
   let(:alma_patron_stub) do
-    old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", status: 400)
+    stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", status: 400)
   end
   let(:illiad_stub) do
     stub_illiad_get_request(url: "Users/tutor", status: 404)
@@ -79,7 +79,7 @@ describe "authentication requests" do
     it "returns 401 response" do
       env "HTTP_X_AUTH_REQUEST_USER", nil
       get "/"
-      old_stub_alma_get_request(url: "users/?expand=none&user_id_type=all_unique&view=full", status: 400)
+      stub_alma_get_request(url: "users/?expand=none&user_id_type=all_unique&view=full", status: 400)
       expect(last_response.status).to eq(401)
     end
   end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -15,7 +15,7 @@ describe "authentication requests" do
     }
   }
   let(:alma_patron_stub) do
-    stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", status: 400)
+    old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", status: 400)
   end
   let(:illiad_stub) do
     stub_illiad_get_request(url: "Users/tutor", status: 404)
@@ -79,7 +79,7 @@ describe "authentication requests" do
     it "returns 401 response" do
       env "HTTP_X_AUTH_REQUEST_USER", nil
       get "/"
-      stub_alma_get_request(url: "users/?expand=none&user_id_type=all_unique&view=full", status: 400)
+      old_stub_alma_get_request(url: "users/?expand=none&user_id_type=all_unique&view=full", status: 400)
       expect(last_response.status).to eq(401)
     end
   end

--- a/spec/requests/current_checkouts_spec.rb
+++ b/spec/requests/current_checkouts_spec.rb
@@ -37,7 +37,7 @@ describe "current-checkouts requests" do
   context "get /current-checkouts/u-m-library" do
     context "in alma user" do
       before(:each) do
-        stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"})
+        old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"})
       end
       it "contains 'U-M Library'" do
         get "/current-checkouts/u-m-library"
@@ -46,7 +46,7 @@ describe "current-checkouts requests" do
     end
     context "in alma user but alma has a network problem" do
       it "loads the empty state and has an error flash" do
-        stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"}, status: 500)
+        old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"}, status: 500)
         get "/current-checkouts/u-m-library"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -102,17 +102,17 @@ describe "current-checkouts requests" do
   # ToDO
   # context "post /renew-loan" do
   # before(:each) do
-  # stub_alma_get_request(url: "users/tutor/loans", query: {expand: 'renewable'})
+  # old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: 'renewable'})
   # end
   # it "handles good request" do
-  # stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'} )
+  # old_stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'} )
   # post "/renew-loan", {'loan_id' => '1234'}
   # expect(URI(last_response.headers["Location"]).path).to eq("/current-checkouts/loans")
   # follow_redirect!
   # expect(last_response.body).to include("Loan Successfully Renewed")
   # end
   # it "handles bad request" do
-  # stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'}, status: 500 )
+  # old_stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'}, status: 500 )
   # post "/renew-loan", {'loan_id' => '1234'}
   # expect(URI(last_response.headers["Location"]).path).to eq("/current-checkouts/loans")
   # follow_redirect!

--- a/spec/requests/current_checkouts_spec.rb
+++ b/spec/requests/current_checkouts_spec.rb
@@ -37,7 +37,7 @@ describe "current-checkouts requests" do
   context "get /current-checkouts/u-m-library" do
     context "in alma user" do
       before(:each) do
-        old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"})
+        stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"})
       end
       it "contains 'U-M Library'" do
         get "/current-checkouts/u-m-library"
@@ -46,7 +46,7 @@ describe "current-checkouts requests" do
     end
     context "in alma user but alma has a network problem" do
       it "loads the empty state and has an error flash" do
-        old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"}, status: 500)
+        stub_alma_get_request(url: "users/tutor/loans", query: {expand: "renewable", limit: 15, order_by: "due_date"}, status: 500)
         get "/current-checkouts/u-m-library"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -99,24 +99,4 @@ describe "current-checkouts requests" do
       expect(last_response.body).to include("Error")
     end
   end
-  # ToDO
-  # context "post /renew-loan" do
-  # before(:each) do
-  # old_stub_alma_get_request(url: "users/tutor/loans", query: {expand: 'renewable'})
-  # end
-  # it "handles good request" do
-  # old_stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'} )
-  # post "/renew-loan", {'loan_id' => '1234'}
-  # expect(URI(last_response.headers["Location"]).path).to eq("/current-checkouts/loans")
-  # follow_redirect!
-  # expect(last_response.body).to include("Loan Successfully Renewed")
-  # end
-  # it "handles bad request" do
-  # old_stub_alma_post_request(url: "users/tutor/loans/1234", query: {op: 'renew'}, status: 500 )
-  # post "/renew-loan", {'loan_id' => '1234'}
-  # expect(URI(last_response.headers["Location"]).path).to eq("/current-checkouts/loans")
-  # follow_redirect!
-  # expect(last_response.body).to include("Error")
-  # end
-  # end
 end

--- a/spec/requests/fines_and_fees_spec.rb
+++ b/spec/requests/fines_and_fees_spec.rb
@@ -24,19 +24,19 @@ describe "fines-and-fees requests" do
   context "get /fines-and-fees" do
     context "in alma user" do
       it "contains 'Fines'" do
-        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
+        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
           body: File.read("spec/fixtures/jbister_fines.json"))
         get "/fines-and-fees"
         expect(last_response.body).to include("Fines")
       end
       it "shows error and empty state if there's an failed alma request" do
-        stub_alma_get_request(url: "users/tutor/fees", status: 500, query: {limit: 100, offset: 0})
+        old_stub_alma_get_request(url: "users/tutor/fees", status: 500, query: {limit: 100, offset: 0})
         get "/fines-and-fees"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
       end
       it "shows error and empty state if there's an timeout" do
-        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
+        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
         get "/fines-and-fees"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -52,7 +52,7 @@ describe "fines-and-fees requests" do
   end
   context "post /fines-and-fees/pay" do
     before(:each) do
-      @stub = stub_alma_get_request(url: "users/tutor/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
+      @stub = old_stub_alma_get_request(url: "users/tutor/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
       stub_request(:post, S.slack_url) # Don't care about the slack url for testing purposes
     end
     it "for pay in full redirects to nelnet with total amountDue" do
@@ -72,7 +72,7 @@ describe "fines-and-fees requests" do
     end
     it "redirects back to fines and fees with an error if there's a network error" do
       remove_request_stub(@stub)
-      stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
+      old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
       post "/fines-and-fees/pay", {"pay_in_full" => "false", "partial_amount" => "100"}
       expect(last_response.status).to eq(302)
       expect(URI(last_response.headers["Location"]).path).to eq("/fines-and-fees")
@@ -110,11 +110,11 @@ describe "fines-and-fees requests" do
     end
     it "for valid params, updates Alma, sets success flash, prints receipt" do
       with_modified_env NELNET_SECRET_KEY: "secret" do
-        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
+        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
           body: File.read("spec/fixtures/jbister_fines.json"))
         @session[:order_number] = "382481568"
         env "rack.session", @session
-        stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"}, body: File.read("spec/fixtures/fines_pay_amount.json"))
+        old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"}, body: File.read("spec/fixtures/fines_pay_amount.json"))
 
         get "/fines-and-fees/receipt", @params
         expect(last_response.body).to include("Fines successfully paid")
@@ -122,7 +122,7 @@ describe "fines-and-fees requests" do
     end
     it "for invalid params,  sets fail flash" do
       with_modified_env NELNET_SECRET_KEY: "incorect_secret" do
-        stub = stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"})
+        stub = old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"})
 
         get "/fines-and-fees/receipt", @params
         expect(last_response.body).to include("Your payment could not be validated")

--- a/spec/requests/fines_and_fees_spec.rb
+++ b/spec/requests/fines_and_fees_spec.rb
@@ -24,19 +24,19 @@ describe "fines-and-fees requests" do
   context "get /fines-and-fees" do
     context "in alma user" do
       it "contains 'Fines'" do
-        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
-          body: File.read("spec/fixtures/jbister_fines.json"))
+        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
+          output: File.read("spec/fixtures/jbister_fines.json"))
         get "/fines-and-fees"
         expect(last_response.body).to include("Fines")
       end
       it "shows error and empty state if there's an failed alma request" do
-        old_stub_alma_get_request(url: "users/tutor/fees", status: 500, query: {limit: 100, offset: 0})
+        stub_alma_get_request(url: "users/tutor/fees", status: 500, query: {limit: 100, offset: 0})
         get "/fines-and-fees"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
       end
       it "shows error and empty state if there's an timeout" do
-        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
+        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
         get "/fines-and-fees"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -52,7 +52,7 @@ describe "fines-and-fees requests" do
   end
   context "post /fines-and-fees/pay" do
     before(:each) do
-      @stub = old_stub_alma_get_request(url: "users/tutor/fees", body: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
+      @stub = stub_alma_get_request(url: "users/tutor/fees", output: File.read("./spec/fixtures/jbister_fines.json"), query: {limit: 100, offset: 0})
       stub_request(:post, S.slack_url) # Don't care about the slack url for testing purposes
     end
     it "for pay in full redirects to nelnet with total amountDue" do
@@ -72,7 +72,7 @@ describe "fines-and-fees requests" do
     end
     it "redirects back to fines and fees with an error if there's a network error" do
       remove_request_stub(@stub)
-      old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
+      stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0}, no_return: true).to_timeout
       post "/fines-and-fees/pay", {"pay_in_full" => "false", "partial_amount" => "100"}
       expect(last_response.status).to eq(302)
       expect(URI(last_response.headers["Location"]).path).to eq("/fines-and-fees")
@@ -110,11 +110,11 @@ describe "fines-and-fees requests" do
     end
     it "for valid params, updates Alma, sets success flash, prints receipt" do
       with_modified_env NELNET_SECRET_KEY: "secret" do
-        old_stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
-          body: File.read("spec/fixtures/jbister_fines.json"))
+        stub_alma_get_request(url: "users/tutor/fees", query: {limit: 100, offset: 0},
+          output: File.read("spec/fixtures/jbister_fines.json"))
         @session[:order_number] = "382481568"
         env "rack.session", @session
-        old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"}, body: File.read("spec/fixtures/fines_pay_amount.json"))
+        stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"}, output: File.read("spec/fixtures/fines_pay_amount.json"))
 
         get "/fines-and-fees/receipt", @params
         expect(last_response.body).to include("Fines successfully paid")
@@ -122,7 +122,7 @@ describe "fines-and-fees requests" do
     end
     it "for invalid params,  sets fail flash" do
       with_modified_env NELNET_SECRET_KEY: "incorect_secret" do
-        stub = old_stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"})
+        stub = stub_alma_post_request(url: "users/tutor/fees/all", query: {op: "pay", amount: "22.50", method: "ONLINE", external_transaction_id: "382481568"})
 
         get "/fines-and-fees/receipt", @params
         expect(last_response.body).to include("Your payment could not be validated")

--- a/spec/requests/pending_requests_spec.rb
+++ b/spec/requests/pending_requests_spec.rb
@@ -37,7 +37,7 @@ describe "requests" do
   context "get /pending-requests/u-m-library" do
     context "in alma" do
       it "contains 'U-M Library'" do
-        stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
+        old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
         stub_illiad_get_request(url: "Users/tutor", status: 404)
         stub_illiad_get_request(url: "Transaction/UserRequests/tutor",
           body: "[]", query: hash_excluding({just_pass: "for_real"}))
@@ -45,7 +45,7 @@ describe "requests" do
         expect(last_response.body).to include("U-M Library")
       end
       it "loads empty state when theres an error with an alma request" do
-        stub_alma_get_request(url: "users/tutor/requests", status: 500, query: {limit: 100, offset: 0})
+        old_stub_alma_get_request(url: "users/tutor/requests", status: 500, query: {limit: 100, offset: 0})
         get "/pending-requests/u-m-library"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -77,15 +77,15 @@ describe "requests" do
   end
   context "post /pending-requests/u-m-library/cancel-request" do
     before(:each) do
-      @req = stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"))
+      @req = old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"))
     end
     it "handles good cancel request" do
-      stub_alma_delete_request(url: "users/tutor/requests/1234", status: 204, body: "{}", query: {reason: "CancelledAtPatronRequest"})
+      old_stub_alma_delete_request(url: "users/tutor/requests/1234", status: 204, body: "{}", query: {reason: "CancelledAtPatronRequest"})
       post "/pending-requests/u-m-library/cancel-request", {"request_id" => "1234"}
       expect(last_response.status).to eq(200)
     end
     it "handles a bad cancel request" do
-      stub_alma_delete_request(url: "users/tutor/requests/1234", query: {reason: "CancelledAtPatronRequest"}, no_return: true).to_timeout
+      old_stub_alma_delete_request(url: "users/tutor/requests/1234", query: {reason: "CancelledAtPatronRequest"}, no_return: true).to_timeout
       post "/pending-requests/u-m-library/cancel-request", {"request_id" => "1234"}
       expect(last_response.status).to eq(500)
     end

--- a/spec/requests/pending_requests_spec.rb
+++ b/spec/requests/pending_requests_spec.rb
@@ -37,7 +37,7 @@ describe "requests" do
   context "get /pending-requests/u-m-library" do
     context "in alma" do
       it "contains 'U-M Library'" do
-        old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
+        stub_alma_get_request(url: "users/tutor/requests", output: File.read("./spec/fixtures/requests.json"), query: {limit: 100, offset: 0})
         stub_illiad_get_request(url: "Users/tutor", status: 404)
         stub_illiad_get_request(url: "Transaction/UserRequests/tutor",
           body: "[]", query: hash_excluding({just_pass: "for_real"}))
@@ -45,7 +45,7 @@ describe "requests" do
         expect(last_response.body).to include("U-M Library")
       end
       it "loads empty state when theres an error with an alma request" do
-        old_stub_alma_get_request(url: "users/tutor/requests", status: 500, query: {limit: 100, offset: 0})
+        stub_alma_get_request(url: "users/tutor/requests", status: 500, query: {limit: 100, offset: 0})
         get "/pending-requests/u-m-library"
         expect(last_response.body).to include("You don't have")
         expect(last_response.body).to include("Error")
@@ -77,15 +77,15 @@ describe "requests" do
   end
   context "post /pending-requests/u-m-library/cancel-request" do
     before(:each) do
-      @req = old_stub_alma_get_request(url: "users/tutor/requests", body: File.read("./spec/fixtures/requests.json"))
+      @req = stub_alma_get_request(url: "users/tutor/requests", output: File.read("./spec/fixtures/requests.json"))
     end
     it "handles good cancel request" do
-      old_stub_alma_delete_request(url: "users/tutor/requests/1234", status: 204, body: "{}", query: {reason: "CancelledAtPatronRequest"})
+      stub_alma_delete_request(url: "users/tutor/requests/1234", status: 204, output: "{}", query: {reason: "CancelledAtPatronRequest"})
       post "/pending-requests/u-m-library/cancel-request", {"request_id" => "1234"}
       expect(last_response.status).to eq(200)
     end
     it "handles a bad cancel request" do
-      old_stub_alma_delete_request(url: "users/tutor/requests/1234", query: {reason: "CancelledAtPatronRequest"}, no_return: true).to_timeout
+      stub_alma_delete_request(url: "users/tutor/requests/1234", query: {reason: "CancelledAtPatronRequest"}, no_return: true).to_timeout
       post "/pending-requests/u-m-library/cancel-request", {"request_id" => "1234"}
       expect(last_response.status).to eq(500)
     end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -32,7 +32,7 @@ describe "requests" do
   end
   context "get /" do
     it "contains 'Account Overview'" do
-      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
+      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
       get "/"
       expect(last_response.body).to include("Account Overview")
     end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -32,7 +32,7 @@ describe "requests" do
   end
   context "get /" do
     it "contains 'Account Overview'" do
-      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
+      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
       get "/"
       expect(last_response.body).to include("Account Overview")
     end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -18,7 +18,7 @@ describe "requests" do
   end
   context "get /settings" do
     it "contains 'Settings'" do
-      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
+      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", output: "{}")
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
       get "/settings"
@@ -28,7 +28,7 @@ describe "requests" do
   context "post /settings/history" do
     before(:each) do
       @patron_json = File.read("./spec/fixtures/mrio_user_alma.json")
-      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
+      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", output: @patron_json)
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
     end
@@ -51,7 +51,7 @@ describe "requests" do
   context "post /sms" do
     before(:each) do
       @patron_json = File.read("./spec/fixtures/mrio_user_alma.json")
-      @stub = old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
+      @stub = stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", output: @patron_json)
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
     end
@@ -60,7 +60,7 @@ describe "requests" do
       new_phone_patron = JSON.parse(@patron_json)
       new_phone_patron["contact_info"]["phone"][1]["phone_number"] = sms_number
 
-      old_stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
+      stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
 
       post "/sms", {"text-notifications" => "on", "sms-number" => sms_number}
       follow_redirect!
@@ -74,14 +74,14 @@ describe "requests" do
     it "handles phone number removal" do
       new_phone_patron = JSON.parse(@patron_json)
       new_phone_patron["contact_info"]["phone"].delete_at(1)
-      old_stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
+      stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
       post "/sms", {"text-notifications" => "off", "sms-number" => ""}
       follow_redirect!
       expect(last_response.body).to include("successfully removed")
     end
     it "handles a network error" do
       remove_request_stub(@stub)
-      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", no_return: true).to_timeout
+      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", no_return: true).to_timeout
       post "/sms", {"text-notifications" => "off", "sms-number" => ""}
       session = last_request.env["rack.session"]
       expect(session["flash"][:error]).to include("We were unable")

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -18,7 +18,7 @@ describe "requests" do
   end
   context "get /settings" do
     it "contains 'Settings'" do
-      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
+      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full")
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
       get "/settings"
@@ -28,7 +28,7 @@ describe "requests" do
   context "post /settings/history" do
     before(:each) do
       @patron_json = File.read("./spec/fixtures/mrio_user_alma.json")
-      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
+      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
     end
@@ -51,7 +51,7 @@ describe "requests" do
   context "post /sms" do
     before(:each) do
       @patron_json = File.read("./spec/fixtures/mrio_user_alma.json")
-      @stub = stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
+      @stub = old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", body: @patron_json)
       stub_circ_history_get_request(url: "users/tutor")
       stub_illiad_get_request(url: "Users/tutor", status: 404)
     end
@@ -60,7 +60,7 @@ describe "requests" do
       new_phone_patron = JSON.parse(@patron_json)
       new_phone_patron["contact_info"]["phone"][1]["phone_number"] = sms_number
 
-      stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
+      old_stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
 
       post "/sms", {"text-notifications" => "on", "sms-number" => sms_number}
       follow_redirect!
@@ -74,14 +74,14 @@ describe "requests" do
     it "handles phone number removal" do
       new_phone_patron = JSON.parse(@patron_json)
       new_phone_patron["contact_info"]["phone"].delete_at(1)
-      stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
+      old_stub_alma_put_request(url: "users/mrio", input: new_phone_patron.to_json, output: new_phone_patron.to_json)
       post "/sms", {"text-notifications" => "off", "sms-number" => ""}
       follow_redirect!
       expect(last_response.body).to include("successfully removed")
     end
     it "handles a network error" do
       remove_request_stub(@stub)
-      stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", no_return: true).to_timeout
+      old_stub_alma_get_request(url: "users/tutor?expand=none&user_id_type=all_unique&view=full", no_return: true).to_timeout
       post "/sms", {"text-notifications" => "off", "sms-number" => ""}
       session = last_request.env["rack.session"]
       expect(session["flash"][:error]).to include("We were unable")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -129,18 +129,19 @@ end
   end
 end
 
-[:get, :post, :delete].each do |name|
-  define_method(:"stub_alma_#{name}_request") do |url:, body: "{}", status: 200, query: {}, no_return: nil|
-    req = stub_request(name, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
-      headers: {
-        :accept => "application/json",
-        :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "User-Agent" => "Ruby"
-      },
-      query: query
-    )
-    req.to_return(body: body, status: status, headers: {content_type: "application/json"}) if no_return.nil?
+[:get, :post, :put, :delete].each do |name|
+  define_method(:"stub_alma_#{name}_request") do |url:, input: nil, output: "", status: 200, query: nil, no_return: nil|
+    req_attributes = {}
+    req_attributes[:headers] = {
+      "Authorization" => "apikey #{ENV["ALMA_API_KEY"]}"
+    }
+    req_attributes[:body] = input unless input.nil?
+    req_attributes[:query] = query unless query.nil?
+
+    resp = {headers: {content_type: "application/json"}, status: status, body: output}
+
+    req = stub_request(name, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url.sub(/^\//, "")}").with(**req_attributes)
+    req.to_return(**resp) if no_return.nil?
     req
   end
 end
@@ -159,21 +160,6 @@ end
     req.to_return(body: body, status: status, headers: {content_type: "application/json"}) if no_return.nil?
     req
   end
-end
-
-def stub_alma_put_request(url:, input:, output:, status: 200, no_return: nil)
-  req = stub_request(:put, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
-    body: input,
-    headers: {
-      :accept => "application/json",
-      :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
-      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-      "User-Agent" => "Ruby",
-      "Content-Type" => "application/json"
-    }
-  )
-  req.to_return(body: output, status: status, headers: {content_type: "application/json"}) if no_return.nil?
-  req
 end
 
 def old_stub_alma_put_request(url:, input:, output:, status: 200, no_return: nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require File.expand_path "../../account.rb", __FILE__
 
 module RSpecMixin
   include Rack::Test::Methods
+  include AlmaRestClient::Test::Helpers
 
   def app = Sinatra::Application
 end
@@ -125,23 +126,6 @@ end
       query: query
     )
     req.to_return(body: output, status: status, headers: {content_type: "application/json"}) if no_return.nil?
-    req
-  end
-end
-
-[:get, :post, :put, :delete].each do |name|
-  define_method(:"stub_alma_#{name}_request") do |url:, input: nil, output: "", status: 200, query: nil, no_return: nil|
-    req_attributes = {}
-    req_attributes[:headers] = {
-      "Authorization" => "apikey #{ENV["ALMA_API_KEY"]}"
-    }
-    req_attributes[:body] = input unless input.nil?
-    req_attributes[:query] = query unless query.nil?
-
-    resp = {headers: {content_type: "application/json"}, status: status, body: output}
-
-    req = stub_request(name, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url.sub(/^\//, "")}").with(**req_attributes)
-    req.to_return(**resp) if no_return.nil?
     req
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,7 +144,39 @@ end
     req
   end
 end
+
+[:get, :post, :delete].each do |name|
+  define_method(:"old_stub_alma_#{name}_request") do |url:, body: "{}", status: 200, query: {}, no_return: nil|
+    req = stub_request(name, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
+      headers: {
+        :accept => "application/json",
+        :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
+        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        "User-Agent" => "Ruby"
+      },
+      query: query
+    )
+    req.to_return(body: body, status: status, headers: {content_type: "application/json"}) if no_return.nil?
+    req
+  end
+end
+
 def stub_alma_put_request(url:, input:, output:, status: 200, no_return: nil)
+  req = stub_request(:put, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
+    body: input,
+    headers: {
+      :accept => "application/json",
+      :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
+      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "User-Agent" => "Ruby",
+      "Content-Type" => "application/json"
+    }
+  )
+  req.to_return(body: output, status: status, headers: {content_type: "application/json"}) if no_return.nil?
+  req
+end
+
+def old_stub_alma_put_request(url:, input:, output:, status: 200, no_return: nil)
   req = stub_request(:put, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
     body: input,
     headers: {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,37 +146,6 @@ end
   end
 end
 
-[:get, :post, :delete].each do |name|
-  define_method(:"old_stub_alma_#{name}_request") do |url:, body: "{}", status: 200, query: {}, no_return: nil|
-    req = stub_request(name, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
-      headers: {
-        :accept => "application/json",
-        :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "User-Agent" => "Ruby"
-      },
-      query: query
-    )
-    req.to_return(body: body, status: status, headers: {content_type: "application/json"}) if no_return.nil?
-    req
-  end
-end
-
-def old_stub_alma_put_request(url:, input:, output:, status: 200, no_return: nil)
-  req = stub_request(:put, "#{ENV["ALMA_API_HOST"]}/almaws/v1/#{url}").with(
-    body: input,
-    headers: {
-      :accept => "application/json",
-      :Authorization => "apikey #{ENV["ALMA_API_KEY"]}",
-      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-      "User-Agent" => "Ruby",
-      "Content-Type" => "application/json"
-    }
-  )
-  req.to_return(body: output, status: status, headers: {content_type: "application/json"}) if no_return.nil?
-  req
-end
-
 def stub_illiad_get_request(url:, body: "{}", status: 200, query: nil, no_return: nil)
   req = stub_request(:get, "#{ENV["ILLIAD_API_HOST"]}/ILLiadWebPlatform/#{url}").with(
     headers: {


### PR DESCRIPTION
# Overview

When `alma_rest_client` changed to using Faraday, the response objects changed from HTTParty responses to Faraday responses. This was a major breaking change, so we'd put off updated. This gets account to use the updated gem. 

It also changes the use of the term `parsed_response` to the more generic and shorter `body`.

This PR does not change the Illiad Client or the Checkout History client. They still use HTTParty. We should get off of it, but this PR is pretty big already.  